### PR TITLE
Performance optimization

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,4 +2,4 @@
 set -e
 SCRIPT_DIRECTORY="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 source "$SCRIPT_DIRECTORY/common.sh"
-kompile $KOMPILE_OPTS $* "$SCRIPT_DIRECTORY/unit-test.k" && "$SCRIPT_DIRECTORY/compat/kompile-all.sh"
+kompile $KOMPILE_OPTS $* --gen-bison-parser "$SCRIPT_DIRECTORY/unit-test.k" && "$SCRIPT_DIRECTORY/compat/kompile-all.sh"

--- a/compat/michelson-unparser.k
+++ b/compat/michelson-unparser.k
@@ -368,7 +368,7 @@ module MICHELSON-UNPARSER
     "; " +String 
     #doUnparse(Gs, false)
 
-  rule #doUnparse(Gs:Groups ;, _) => #doUnparse(Gs, false) +String ";"
+  rule #doUnparse(Gs:Group ;, _) => #doUnparse(Gs, false) +String ";"
 
   rule #doUnparse(Stack_elt T D, _) =>
     "Stack_elt " +String

--- a/michelson-common.k
+++ b/michelson-common.k
@@ -43,19 +43,19 @@ module MICHELSON-COMMON
   syntax Int ::= "#GroupOrderMax" [function]
   rule #GroupOrderMax => 1000
 
-  rule True => true [macro]
-  rule False => false [macro]
+  rule `MichelsonBool`(True) => true
+  rule `MichelsonBool`(False) => false
 
-  rule code B ; storage St ; parameter Pt => code B ; storage St ; parameter Pt ; [macro]
-  rule code B ; parameter Pt ; storage St => code B ; storage St ; parameter Pt ; [macro]
-  rule storage St ; code B ; parameter Pt => code B ; storage St ; parameter Pt ; [macro]
-  rule parameter Pt ; code B ; storage St => code B ; storage St ; parameter Pt ; [macro]
-  rule storage St ; parameter Pt ; code B => code B ; storage St ; parameter Pt ; [macro]
-  rule parameter Pt ; storage St ; code B => code B ; storage St ; parameter Pt ; [macro]
+  rule code B ; storage St ; parameter Pt => code B ; storage St ; parameter Pt ; [anywhere]
+  rule code B ; parameter Pt ; storage St => code B ; storage St ; parameter Pt ; [anywhere]
+  rule storage St ; code B ; parameter Pt => code B ; storage St ; parameter Pt ; [anywhere]
+  rule parameter Pt ; code B ; storage St => code B ; storage St ; parameter Pt ; [anywhere]
+  rule storage St ; parameter Pt ; code B => code B ; storage St ; parameter Pt ; [anywhere]
+  rule parameter Pt ; storage St ; code B => code B ; storage St ; parameter Pt ; [anywhere]
 
-  rule code B ; parameter Pt ; storage St ; => code B ; storage St ; parameter Pt ; [macro]
-  rule storage St ; code B ; parameter Pt ; => code B ; storage St ; parameter Pt ; [macro]
-  rule parameter Pt ; code B ; storage St ; => code B ; storage St ; parameter Pt ; [macro]
-  rule storage St ; parameter Pt ; code B ; => code B ; storage St ; parameter Pt ; [macro]
-  rule parameter Pt ; storage St ; code B ; => code B ; storage St ; parameter Pt ; [macro]
+  rule code B ; parameter Pt ; storage St ; => code B ; storage St ; parameter Pt ; [anywhere]
+  rule storage St ; code B ; parameter Pt ; => code B ; storage St ; parameter Pt ; [anywhere]
+  rule parameter Pt ; code B ; storage St ; => code B ; storage St ; parameter Pt ; [anywhere]
+  rule storage St ; parameter Pt ; code B ; => code B ; storage St ; parameter Pt ; [anywhere]
+  rule parameter Pt ; storage St ; code B ; => code B ; storage St ; parameter Pt ; [anywhere]
 endmodule

--- a/michelson-config.k
+++ b/michelson-config.k
@@ -6,7 +6,7 @@ module MICHELSON-CONFIG
   imports MICHELSON-COMMON
   imports DOMAINS
 
-  rule <k> Gs:Groups ; => Gs </k> [owise]
+  rule <k> Gs:Group ; => Gs </k> [owise]
 
   configuration <michelsonTop>
                   <k> $PGM:Pgm </k>

--- a/michelson-syntax.k
+++ b/michelson-syntax.k
@@ -321,6 +321,6 @@ module MICHELSON-SYNTAX
                  | ContractsGroup
                  | BigMapGroup
 
-  syntax Groups ::= Group | Group ";" Groups
-  syntax Pgm ::= Groups | Groups ";"
+  syntax Groups ::= Group | Group ";" Groups | Group ";"
+  syntax Pgm ::= Groups
 endmodule

--- a/michelson-syntax.k
+++ b/michelson-syntax.k
@@ -61,7 +61,7 @@ module MICHELSON-SYNTAX
 
   syntax SimpleData ::= Int
   syntax SimpleData ::= String 
-  syntax SimpleData ::= MichelsonBool
+  syntax Data ::= MichelsonBool [klabel(MichelsonBool), symbol, function, avoid]
   syntax SimpleData ::= MBytesLiteral
   syntax SimpleData ::= "Unit" 
   syntax SimpleData ::= Timestamp 

--- a/michelson.k
+++ b/michelson.k
@@ -191,6 +191,7 @@ module MICHELSON
 
   syntax Groups ::= #InsertionSort(Groups) [function] // Note that this is a *stable* insertion sort.
   rule #InsertionSort(G:Group) => G
+  rule #InsertionSort(G:Group;) => G
   rule #InsertionSort(G ; Gs) => #InsertInOrder(#InsertionSort(Gs), G)
 
   syntax Contract ::= #FindContract(Groups) [function]
@@ -207,6 +208,7 @@ module MICHELSON
   syntax Bool ::= #HasContract(Groups) [function]
   rule #HasContract(contract { C }) => true
   rule #HasContract(contract { C } ; _) => true
+  rule #HasContract(G ;) => #HasContract(G)
   rule #HasContract(_ ; Gs) => #HasContract(Gs) [owise]
   rule #HasContract(_:Group) => false [owise]
 

--- a/michelson.k
+++ b/michelson.k
@@ -293,7 +293,7 @@ module MICHELSON
 
   rule <k> #LoadGroups(C:ContractGroup ; Cs) => #LoadGroups(C) </k>
 
-  rule <k> #LoadGroups(contract { code C ; storage _ ; parameter _ }) => C </k>
+  rule <k> #LoadGroups(contract { code C ; storage _ ; parameter _ ; }) => C </k>
        <stack> . => Pair P S </stack>
        <paramvalue> P </paramvalue>
        <storagevalue> S </storagevalue>
@@ -302,7 +302,7 @@ module MICHELSON
   rule I:Instruction ; Is:InstructionList => I ~> Is 
   rule {} => .K [structrual]
   rule { Is:InstructionList } => Is 
-  rule { Is:InstructionList ; } => { Is } [macro]
+  rule { Is:InstructionList ; } => { Is } [anywhere]
 
   syntax KItem ::= #HandleAnnotations(AnnotationList)
   rule #HandleAnnotations(_) => . 

--- a/parser.sh
+++ b/parser.sh
@@ -11,8 +11,8 @@ if which tezos-client>/dev/null 2>&1; then
     "$EXTRACTOR_DIR/run.sh" "$1" 'code_or_contract' 'false' > "$GROUP_FILE" ;
     GROUP="$(grep -Eo '^\s*(code|contract)' "$GROUP_FILE")" ;
     tezos-client 'expand' 'macros' 'in' "$(sed -E 's/^\s*(code|contract)\s*(.*);/\2/' "$GROUP_FILE")" | tr -d '\n' | sed -E "s/(.*)/$GROUP {\\1} ;/;s/{{/{/g;s/}}/}/g" | cat - "$1" > "$EXPANDED_FILE" ;
-    kast --directory "$SCRIPT_DIR" --expand-macros "$EXPANDED_FILE" || cat "$EXPANDED_FILE" > /dev/stdout;
+    "$SCRIPT_DIR/unit-test-kompiled/parser_PGM" "$EXPANDED_FILE"
 else
     echo 'tezos-client not found, using normal parsing' >/dev/stderr ;
-    kast "$1" --directory "$SCRIPT_DIR" --expand-macros ;
+    "$SCRIPT_DIR/unit-test-kompiled/parser_PGM" "$1"
 fi

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 SCRIPT_DIRECTORY="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 source "$SCRIPT_DIRECTORY/common.sh"
-krun --directory "$SCRIPT_DIRECTORY" --parser "$SCRIPT_DIRECTORY/parser.sh" $*
+TEMP_DIR="$(mktemp -d)" ;
+trap 'rm -rf "$TEMP_DIR"' EXIT ;
+"$SCRIPT_DIRECTORY/parser.sh" "$*" > "$TEMP_DIR/input.kore"
+llvm-krun -d "$SCRIPT_DIRECTORY/unit-test-kompiled" -c PGM "$TEMP_DIR/input.kore" Pgm korefile -o "$TEMP_DIR/output.kore" || cat "$TEMP_DIR/output.kore"

--- a/run.sh
+++ b/run.sh
@@ -4,4 +4,4 @@ source "$SCRIPT_DIRECTORY/common.sh"
 TEMP_DIR="$(mktemp -d)" ;
 trap 'rm -rf "$TEMP_DIR"' EXIT ;
 "$SCRIPT_DIRECTORY/parser.sh" "$*" > "$TEMP_DIR/input.kore"
-llvm-krun -d "$SCRIPT_DIRECTORY/unit-test-kompiled" -c PGM "$TEMP_DIR/input.kore" Pgm korefile -o "$TEMP_DIR/output.kore" || cat "$TEMP_DIR/output.kore"
+llvm-krun -d "$SCRIPT_DIRECTORY/unit-test-kompiled" -c PGM "$TEMP_DIR/input.kore" Pgm korefile -o "$TEMP_DIR/output.kore" || kast -d "$SCRIPT_DIRECTORY" -i kore -o pretty "$TEMP_DIR/output.kore"


### PR DESCRIPTION
We no longer invoke the java frontend unless the test fails, which substantially improves performance. In order to do this, we generate a parser with Bison rather than relying on the java `kast` parser to parse programs. We also transform the semantics slightly to account for the limitations of this approach, like lack of support for macros and a lack of support for non-LALR(1) grammars.