### PR TITLE
fix unpack semantics and update unit tests

### DIFF
--- a/michelson.md
+++ b/michelson.md
@@ -1257,7 +1257,7 @@ The bytes instructions have a stubbed implementation for the time being, since t
        <stack> T => #Packed(T) ... </stack>
 
   rule <k> UNPACK A _ => #HandleAnnotations(A) ... </k>
-       <stack> #Packed(T) => T ... </stack>
+       <stack> #Packed(T) => Some T ... </stack>
 ```
 
 The concat operation over two bytes is relatively straightforward since we already have helper functions to extract bytes content.

--- a/tests/unit/packunpack_address_00.tzt
+++ b/tests/unit/packunpack_address_00.tzt
@@ -1,3 +1,3 @@
 code { PACK ; UNPACK address } ;
 input { Stack_elt address "tz1cxcwwnzENRdhe2Kb8ZdTrdNy4bFNyScx5" } ;
-output { Stack_elt address "tz1cxcwwnzENRdhe2Kb8ZdTrdNy4bFNyScx5" }
+output { Stack_elt (option address) (Some "tz1cxcwwnzENRdhe2Kb8ZdTrdNy4bFNyScx5") }

--- a/tests/unit/packunpack_bool_00.tzt
+++ b/tests/unit/packunpack_bool_00.tzt
@@ -1,3 +1,3 @@
 code { PACK ; UNPACK bool } ;
 input { Stack_elt bool False } ;
-output { Stack_elt bool False }
+output { Stack_elt (option bool) (Some False) }

--- a/tests/unit/packunpack_bytes_00.tzt
+++ b/tests/unit/packunpack_bytes_00.tzt
@@ -1,3 +1,3 @@
 code { PACK ; UNPACK bytes } ;
 input { Stack_elt bytes 0x00AABBCC } ;
-output { Stack_elt bytes 0x00AABBCC }
+output { Stack_elt (option bytes) (Some 0x00AABBCC) }

--- a/tests/unit/packunpack_int_00.tzt
+++ b/tests/unit/packunpack_int_00.tzt
@@ -1,3 +1,3 @@
 code { PACK ; UNPACK int } ;
 input { Stack_elt int -1 } ;
-output { Stack_elt int -1 }
+output { Stack_elt (option int) (Some -1) }

--- a/tests/unit/packunpack_keyhash_00.tzt
+++ b/tests/unit/packunpack_keyhash_00.tzt
@@ -1,3 +1,3 @@
 code { PACK ; UNPACK key_hash } ;
 input { Stack_elt key_hash "tz1cxcwwnzENRdhe2Kb8ZdTrdNy4bFNyScx5" } ;
-output { Stack_elt key_hash "tz1cxcwwnzENRdhe2Kb8ZdTrdNy4bFNyScx5" }
+output { Stack_elt (option key_hash) (Some "tz1cxcwwnzENRdhe2Kb8ZdTrdNy4bFNyScx5") }

--- a/tests/unit/packunpack_mutez_00.tzt
+++ b/tests/unit/packunpack_mutez_00.tzt
@@ -1,3 +1,3 @@
 code { PACK ; UNPACK mutez } ;
 input { Stack_elt mutez 1000 } ;
-output { Stack_elt mutez 1000 }
+output { Stack_elt (option mutez) (Some 1000) }

--- a/tests/unit/packunpack_nat_00.tzt
+++ b/tests/unit/packunpack_nat_00.tzt
@@ -1,3 +1,3 @@
 code { PACK ; UNPACK nat } ;
 input { Stack_elt nat 1 } ;
-output { Stack_elt nat 1 }
+output { Stack_elt (option nat) (Some 1) }

--- a/tests/unit/packunpack_string_00.tzt
+++ b/tests/unit/packunpack_string_00.tzt
@@ -1,3 +1,3 @@
 code { PACK ; UNPACK string } ;
 input { Stack_elt string "foobar" } ;
-output { Stack_elt string "foobar" }
+output { Stack_elt (option string) (Some "foobar") }

--- a/tests/unit/packunpack_timestamp_00.tzt
+++ b/tests/unit/packunpack_timestamp_00.tzt
@@ -1,3 +1,3 @@
 code { PACK ; UNPACK timestamp } ;
 input { Stack_elt timestamp "2019-09-09T08:35:33Z" } ;
-output { Stack_elt timestamp "2019-09-09T08:35:33Z" }
+output { Stack_elt (option timestamp) (Some "2019-09-09T08:35:33Z") }


### PR DESCRIPTION
`UNPACK type` has return type `option type` which our semantics doesn't correctly capture --- bug was found by running cross-validation tests.

Marked as draft because this will be an easy merge after we merge in other more important stuff.