### PR TITLE
Use K DockerHub images on CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 ARG K_COMMIT
 FROM runtimeverificationinc/kframework-k:ubuntu-bionic-${K_COMMIT}
 
+RUN    sudo apt-get update                                   \
+    && sudo apt-get upgrade --yes                            \
+    && sudo apt-get install --yes software-properties-common \
+    && sudo add-apt-repository ppa:avsm/ppa
+
 RUN    sudo apt-get update              \
     && sudo apt-get upgrade --yes       \
     && sudo apt-get install --yes       \
@@ -10,6 +15,7 @@ RUN    sudo apt-get update              \
                     libprocps-dev       \
                     libsecp256k1-dev    \
                     libssl-dev          \
+                    opam                \
                     pandoc              \
                     pcregrep            \
                     pkg-config          \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,5 +27,5 @@ RUN    sudo apt-get update              \
 RUN mkdir -p /home/user/.ssh
 ADD --chown=user:user ssh/config /home/user/.ssh/
 RUN    chmod go-rwx -R /home/user/.ssh                                \
-    && git config --global user.email "admin@runtimeverification.com" \
-    && git config --global user.name  "RV Jenkins"
+    && git config --global user.email 'admin@runtimeverification.com' \
+    && git config --global user.name  'RV Jenkins'

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,23 +6,25 @@ RUN    apt-get update                                   \
     && apt-get install --yes software-properties-common \
     && add-apt-repository ppa:avsm/ppa
 
-RUN    apt-get update              \
-    && apt-get upgrade --yes       \
-    && apt-get install --yes       \
-               cmake               \
-               jq                  \
-               libcrypto++-dev     \
-               libprocps-dev       \
-               libsecp256k1-dev    \
-               libssl-dev          \
-               opam                \
-               pandoc              \
-               pcregrep            \
-               pkg-config          \
-               python3             \
-               python-pygments     \
-               python-recommonmark \
-               python-sphinx
+RUN    apt-get update               \
+    && apt-get upgrade --yes        \
+    && apt-get install --yes        \
+                cmake               \
+                jq                  \
+                libcrypto++-dev     \
+                libev-dev           \
+                libhidapi-dev       \
+                libprocps-dev       \
+                libsecp256k1-dev    \
+                libssl-dev          \
+                opam                \
+                pandoc              \
+                pcregrep            \
+                pkg-config          \
+                python3             \
+                python-pygments     \
+                python-recommonmark \
+                python-sphinx
 
 ARG USER_ID=1000
 ARG GROUP_ID=1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ RUN    apt-get update              \
 
 ARG USER_ID=1000
 ARG GROUP_ID=1000
-RUN    groupadd -g $GROUP_ID user                             \
-    && useradd -m -u $USER_ID -s /bin/sh -g user -G sudo user
+RUN    groupadd -g $GROUP_ID user                     \
+    && useradd -m -u $USER_ID -s /bin/sh -g user user
 
 USER user:user
 WORKDIR /home/user

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,3 +29,5 @@ ADD --chown=user:user ssh/config /home/user/.ssh/
 RUN    chmod go-rwx -R /home/user/.ssh                                \
     && git config --global user.email 'admin@runtimeverification.com' \
     && git config --global user.name  'RV Jenkins'
+
+ENV OPAMROOT=/home/user/.opam

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,7 @@ RUN    sudo apt-get update              \
 RUN sudo userdel --remove user
 ARG USER_ID=1000
 ARG GROUP_ID=1000
-RUN    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers    \
-    && groupadd -g $GROUP_ID user                             \
+RUN    groupadd -g $GROUP_ID user                             \
     && useradd -m -u $USER_ID -s /bin/sh -g user -G sudo user
 
 USER user:user

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,16 @@ RUN    sudo apt-get update              \
                     python-recommonmark \
                     python-sphinx
 
+RUN sudo userdel --remove user
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+RUN    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers    \
+    && groupadd -g $GROUP_ID user                             \
+    && useradd -m -u $USER_ID -s /bin/sh -g user -G sudo user
+
+USER user:user
+WORKDIR /home/user
+
 RUN mkdir -p /home/user/.ssh
 ADD --chown=user:user ssh/config /home/user/.ssh/
 RUN    chmod go-rwx -R /home/user/.ssh                                \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,7 @@ RUN    apt-get update              \
 
 ARG USER_ID=1000
 ARG GROUP_ID=1000
-RUN    groupadd -g $GROUP_ID user                     \
-    && useradd -m -u $USER_ID -s /bin/sh -g user user
+RUN groupadd -g $GROUP_ID user && useradd -m -u $USER_ID -s /bin/sh -g user user
 
 USER user:user
 WORKDIR /home/user

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,88 +1,22 @@
-FROM runtimeverificationinc/ubuntu:bionic
+ARG K_COMMIT
+FROM runtimeverificationinc/kframework-k:ubuntu-bionic-${K_COMMIT}
 
-# add opam repository
-RUN    apt-get update                                   \
-    && apt-get install --yes software-properties-common \
-    && add-apt-repository ppa:avsm/ppa
-
-# install dependencies
-RUN    apt-get update                \
-    && apt-get upgrade --yes         \
-    && apt-get install --yes         \
-            autoconf                 \
-            bison                    \
-            clang-8                  \
-            cmake                    \
-            curl                     \
-            flex                     \
-            gcc                      \
-            jq                       \
-            libboost-test-dev        \
-            libcrypto++-dev          \
-            libffi-dev               \
-            libgflags-dev            \
-            libjemalloc-dev          \
-            libmpfr-dev              \
-            libprocps-dev            \
-            libprotobuf-dev          \
-            libsecp256k1-dev         \
-            libssl-dev               \
-            libtool                  \
-            libyaml-dev              \
-            lld-8                    \
-            llvm-8-tools             \
-            make                     \
-            maven                    \
-            netcat-openbsd           \
-            opam                     \
-            openjdk-11-jdk           \
-            pandoc                   \
-            pcregrep                 \
-            pkg-config               \
-            protobuf-compiler        \
-            python3                  \
-            python-pygments          \
-            python-recommonmark      \
-            python-sphinx            \
-            rapidjson-dev            \
-            time                     \
-            zlib1g-dev
-
-ADD ext/k/haskell-backend/src/main/native/haskell-backend/scripts/install-stack.sh /.install-stack/
-RUN /.install-stack/install-stack.sh
-
-RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.6.0 \
-    && cd z3                                                        \
-    && python scripts/mk_make.py                                    \
-    && cd build                                                     \
-    && make -j8                                                     \
-    && make install                                                 \
-    && cd ../..                                                     \
-    && rm -rf z3
-
-USER user:user
-
-ENV LC_ALL=C.UTF-8
-ADD --chown=user:user ext/k/haskell-backend/src/main/native/haskell-backend/stack.yaml /home/user/.tmp-haskell/
-ADD --chown=user:user ext/k/haskell-backend/src/main/native/haskell-backend/kore/package.yaml /home/user/.tmp-haskell/kore/
-RUN    cd /home/user/.tmp-haskell \
-    && stack build --only-snapshot
-
-ADD ext/k/pom.xml /home/user/.tmp-maven/
-ADD ext/k/ktree/pom.xml /home/user/.tmp-maven/ktree/
-ADD ext/k/llvm-backend/pom.xml /home/user/.tmp-maven/llvm-backend/
-ADD ext/k/llvm-backend/src/main/native/llvm-backend/matching/pom.xml /home/user/.tmp-maven/llvm-backend/src/main/native/llvm-backend/matching/
-ADD ext/k/haskell-backend/pom.xml /home/user/.tmp-maven/haskell-backend/
-ADD ext/k/ocaml-backend/pom.xml /home/user/.tmp-maven/ocaml-backend/
-ADD ext/k/kernel/pom.xml /home/user/.tmp-maven/kernel/
-ADD ext/k/java-backend/pom.xml /home/user/.tmp-maven/java-backend/
-ADD ext/k/k-distribution/pom.xml /home/user/.tmp-maven/k-distribution/
-ADD ext/k/kore/pom.xml /home/user/.tmp-maven/kore/
-RUN    cd /home/user/.tmp-maven \
-    && mvn dependency:go-offline
-
-ENV LD_LIBRARY_PATH=/usr/local/lib
-ENV PATH=/home/user/.local/bin:$PATH
+RUN    sudo apt-get update              \
+    && sudo apt-get upgrade --yes       \
+    && sudo apt-get install --yes       \
+                    cmake               \
+                    jq                  \
+                    libcrypto++-dev     \
+                    libprocps-dev       \
+                    libsecp256k1-dev    \
+                    libssl-dev          \
+                    pandoc              \
+                    pcregrep            \
+                    pkg-config          \
+                    python3             \
+                    python-pygments     \
+                    python-recommonmark \
+                    python-sphinx
 
 RUN mkdir -p /home/user/.ssh
 ADD --chown=user:user ssh/config /home/user/.ssh/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,29 @@
 ARG K_COMMIT
 FROM runtimeverificationinc/kframework-k:ubuntu-bionic-${K_COMMIT}
 
-RUN    sudo apt-get update                                   \
-    && sudo apt-get upgrade --yes                            \
-    && sudo apt-get install --yes software-properties-common \
-    && sudo add-apt-repository ppa:avsm/ppa
+RUN    apt-get update                                   \
+    && apt-get upgrade --yes                            \
+    && apt-get install --yes software-properties-common \
+    && add-apt-repository ppa:avsm/ppa
 
-RUN    sudo apt-get update              \
-    && sudo apt-get upgrade --yes       \
-    && sudo apt-get install --yes       \
-                    cmake               \
-                    jq                  \
-                    libcrypto++-dev     \
-                    libprocps-dev       \
-                    libsecp256k1-dev    \
-                    libssl-dev          \
-                    opam                \
-                    pandoc              \
-                    pcregrep            \
-                    pkg-config          \
-                    python3             \
-                    python-pygments     \
-                    python-recommonmark \
-                    python-sphinx
+RUN    apt-get update              \
+    && apt-get upgrade --yes       \
+    && apt-get install --yes       \
+               cmake               \
+               jq                  \
+               libcrypto++-dev     \
+               libprocps-dev       \
+               libsecp256k1-dev    \
+               libssl-dev          \
+               opam                \
+               pandoc              \
+               pcregrep            \
+               pkg-config          \
+               python3             \
+               python-pygments     \
+               python-recommonmark \
+               python-sphinx
 
-RUN sudo userdel --remove user
 ARG USER_ID=1000
 ARG GROUP_ID=1000
 RUN    groupadd -g $GROUP_ID user                             \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
     stage('Build and Test') {
       when { changeRequest() }
       stages {
-        stage('Dependencies')          { steps { sh './build-deps.sh'          } }
+        stage('Dependencies')          { steps { sh './build-deps-tezos.sh'    } }
         stage('Build')                 { steps { sh './build.sh'               } }
         stage('Test')                  { steps { sh './run-tests.sh'           } }
         stage('Cross-Validation Test') { steps { sh './compat/run-tests-ci.sh' } }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
   agent {
     dockerfile {
       label 'docker'
-      additionalBuildArgs '--build-arg K_COMMIT=$(cd ext/k && git rev-parse --short=7 HEAD)'
+      additionalBuildArgs '--build-arg K_COMMIT=$(cd ext/k && git rev-parse --short=7 HEAD) --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
     }
   }
   options { ansiColor('xterm') }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,10 @@
 pipeline {
-  agent { dockerfile { label 'docker' } }
+  agent {
+    dockerfile {
+      label 'docker'
+      additionalBuildArgs '--build-arg K_COMMIT=$(cd ext/k && git rev-parse --short=7 HEAD)'
+    }
+  }
   options { ansiColor('xterm') }
   stages {
     stage("Init title") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
   }
   options { ansiColor('xterm') }
   stages {
-    stage("Init title") {
+    stage('Init title') {
       when { changeRequest() }
       steps { script { currentBuild.displayName = "PR ${env.CHANGE_ID}: ${env.CHANGE_TITLE}" } }
     }

--- a/build-deps-k.sh
+++ b/build-deps-k.sh
@@ -9,5 +9,9 @@ CURRENT_DIRECTORY="$(pwd)"
 
 trap "cd '$CURRENT_DIRECTORY'" EXIT
 
-./build-deps-k.sh
-./build-deps-tezos.sh
+K_DIRECTORY="$SCRIPT_DIRECTORY/ext/k"
+
+git submodule update --init --recursive
+
+cd "$K_DIRECTORY"
+mvn package -DskipTests

--- a/build-deps-tezos.sh
+++ b/build-deps-tezos.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+SCRIPT_DIRECTORY="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+source "$SCRIPT_DIRECTORY/common.sh"
+
+CURRENT_DIRECTORY="$(pwd)"
+
+trap "cd '$CURRENT_DIRECTORY'" EXIT
+
+TEZOS_DIRECTORY="$SCRIPT_DIRECTORY/ext/tezos"
+
+git submodule update --init --recursive
+
+cd "$TEZOS_DIRECTORY"
+# ocaml setup
+# --bare               - do not install any base ocaml installation now
+# --no-setup           - do not ask to setup hooks
+# --disable-sandboxing - do not use bwrap which is not supported on our container
+opam init --bare --no-setup --disable-sandboxing
+make build-deps
+eval `opam env`
+make


### PR DESCRIPTION
~Not ready for merge.~

@sskeirik and @Andrew-Miranti this is ready for review now. It makes it so that we use the K dockerhub image on CI, which cuts out the K building steps from every CI run.

I would recommend making a follow-up PR which also tries to install as many of the ocaml dependencies as possible in the Dockerfile, to maximize cacheing and speed up the tezos dependency step. But this should get in first.