### PR TITLE
fix web deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,10 +31,10 @@ pipeline {
                   git clone 'ssh://github.com/runtimeverification/michelson-semantics.git'
                   cd michelson-semantics
                   git checkout -B gh-pages origin/master
+                  # delete all non-markdown files
+                  rm -r $(git ls-files | grep -v '.md$')
                   # delete media directory which we don't care about
                   rm -rf media
-                  # delete all non-markdown files
-                  rm $(git ls-files | grep -v '.md$')
                   git add ./
                   git commit -m 'gh-pages: remove unrelated content'
                   git fetch origin gh-pages


### PR DESCRIPTION
Add `-r` to rm so that we remove submodule directories which get listed by `git ls-files`.
Reorder the file deletion commands so that every file listed by `git ls-files` exists --- obviating the need for a `-f`.