### PR TITLE
fix Jenkinsfile web deploy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,8 +31,9 @@ pipeline {
                   git clone 'ssh://github.com/runtimeverification/michelson-semantics.git'
                   cd michelson-semantics
                   git checkout -B gh-pages origin/master
-                  # delete all non-markdown files
-                  rm -r $(git ls-files | grep -v '.md$')
+                  # delete all non-markdown files EXCEPT the _config.yml file which defines the website theme
+                  # note: since we are in a groovy string, we need to escape each backslash
+                  rm $(git ls-files | grep -v -E '\\.md$|^_config\\.yml$')
                   # delete media directory which we don't care about
                   rm -rf media
                   git add ./


### PR DESCRIPTION
I accidentally deleted the `_config.yml` file in the Jenkinsfile web deploy which defines the website theme. Update the grep regex to ignore this file. Also, ensure that the dot `.` is a literal dot and not a catchall.