### PR TITLE
Re-enable Bison parser and fast unparser

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,16 +20,10 @@ pipeline {
     }
     stage('Test') {
       options { timeout(time: 10, unit: 'MINUTES') }
-      stages {
-        stage('Start KServer') { steps { sh 'spawn-kserver kserver.log' } }
-        stage('Run Tests') {
-          parallel {
-            stage('Unit')             { steps { sh 'make test-unit  -j8' } }
-            stage('Prove')            { steps { sh 'make test-prove -j2' } }
-            stage('Cross-Validation') { steps { sh 'make test-cross -j8' } }
-          }
-          post { always { sh 'stop-kserver || true' } }
-        }
+      parallel {
+        stage('Unit')             { steps { sh 'make test-unit  -j8' } }
+        stage('Prove')            { steps { sh 'make test-prove -j2' } }
+        stage('Cross-Validation') { steps { sh 'make test-cross -j8' } }
       }
     }
     stage('Deploy') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
       }
     }
     stage('Test') {
-      options { timeout(time: 25, unit: 'MINUTES') }
+      options { timeout(time: 10, unit: 'MINUTES') }
       stages {
         stage('Start KServer') { steps { sh 'spawn-kserver kserver.log' } }
         stage('Run Tests') {

--- a/Makefile
+++ b/Makefile
@@ -106,9 +106,9 @@ ALL_FILES          := $(patsubst %, %.k, $(SOURCE_FILES) $(EXTRA_SOURCE_FILES))
 
 tangle_selector := .k
 
-hook_namespaces := TIME MICHELSON
+HOOK_NAMESPACES := TIME MICHELSON
 
-KOMPILE_OPTS += --hook-namespaces "$(hook_namespaces)" --gen-bison-parser
+KOMPILE_OPTS += --hook-namespaces "$(HOOK_NAMESPACES)" --gen-bison-parser
 
 ifneq (,$(RELEASE))
     KOMPILE_OPTS += -O3

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ tangle_selector := .k
 
 hook_namespaces := TIME MICHELSON
 
-KOMPILE_OPTS += --hook-namespaces "$(hook_namespaces)"
+KOMPILE_OPTS += --hook-namespaces "$(hook_namespaces)" --gen-bison-parser
 
 ifneq (,$(RELEASE))
     KOMPILE_OPTS += -O3
@@ -148,7 +148,7 @@ llvm_dir           := $(DEFN_DIR)/llvm
 llvm_files         := $(patsubst %, $(llvm_dir)/%, $(ALL_FILES))
 llvm_main_file     := unit-test
 llvm_main_module   := UNIT-TEST
-llvm_syntax_module := $(llvm_main_module)
+llvm_syntax_module := $(llvm_main_module)-SYNTAX
 llvm_kompiled      := $(llvm_dir)/$(llvm_main_file)-kompiled/interpreter
 
 defn-llvm:  $(llvm_files)
@@ -170,7 +170,7 @@ prove_dir           := $(DEFN_DIR)/prove
 prove_files         := $(patsubst %, $(prove_dir)/%, $(ALL_FILES))
 prove_main_file     := unit-test
 prove_main_module   := UNIT-TEST
-prove_syntax_module := $(prove_main_module)
+prove_syntax_module := $(prove_main_module)-SYNTAX
 prove_kompiled      := $(prove_dir)/$(prove_main_file)-kompiled/definition.kore
 
 defn-prove:  $(prove_files)
@@ -192,7 +192,7 @@ symbolic_dir           := $(DEFN_DIR)/symbolic
 symbolic_files         := $(patsubst %, $(symbolic_dir)/%, $(ALL_FILES))
 symbolic_main_file     := symbolic-unit-test
 symbolic_main_module   := SYMBOLIC-UNIT-TEST
-symbolic_syntax_module := $(symbolic_main_module)
+symbolic_syntax_module := $(symbolic_main_module)-SYNTAX
 symbolic_kompiled      := $(symbolic_dir)/$(symbolic_main_file)-kompiled/definition.kore
 
 defn-symbolic:  $(symbolic_files)
@@ -214,7 +214,7 @@ contract_expander_dir           := $(DEFN_DIR)/contract-expander
 contract_expander_files         := $(patsubst %, $(contract_expander_dir)/%, $(ALL_FILES))
 contract_expander_main_file     := compat
 contract_expander_main_module   := CONTRACT-EXPANDER
-contract_expander_syntax_module := $(contract_expander_main_module)
+contract_expander_syntax_module := $(contract_expander_main_module)-SYNTAX
 contract_expander_kompiled      := $(contract_expander_dir)/$(contract_expander_main_file)-kompiled/interpreter
 
 defn-contract-expander:  $(contract_expander_files)
@@ -236,7 +236,7 @@ extractor_dir           := $(DEFN_DIR)/extractor
 extractor_files         := $(patsubst %, $(extractor_dir)/%, $(ALL_FILES))
 extractor_main_file     := compat
 extractor_main_module   := EXTRACTOR
-extractor_syntax_module := $(extractor_main_module)
+extractor_syntax_module := $(extractor_main_module)-SYNTAX
 extractor_kompiled      := $(extractor_dir)/$(extractor_main_file)-kompiled/interpreter
 
 defn-extractor:  $(extractor_files)
@@ -258,7 +258,7 @@ input_creator_dir           := $(DEFN_DIR)/input-creator
 input_creator_files         := $(patsubst %, $(input_creator_dir)/%, $(ALL_FILES))
 input_creator_main_file     := compat
 input_creator_main_module   := INPUT-CREATOR
-input_creator_syntax_module := $(input_creator_main_module)
+input_creator_syntax_module := $(input_creator_main_module)-SYNTAX
 input_creator_kompiled      := $(input_creator_dir)/$(input_creator_main_file)-kompiled/interpreter
 
 defn-input-creator:  $(input_creator_files)
@@ -280,7 +280,7 @@ output_compare_dir           := $(DEFN_DIR)/output-compare
 output_compare_files         := $(patsubst %, $(output_compare_dir)/%, $(ALL_FILES))
 output_compare_main_file     := compat
 output_compare_main_module   := OUTPUT-COMPARE
-output_compare_syntax_module := $(output_compare_main_module)
+output_compare_syntax_module := $(output_compare_main_module)-SYNTAX
 output_compare_kompiled      := $(output_compare_dir)/$(output_compare_main_file)-kompiled/interpreter
 
 defn-output-compare:  $(output_compare_files)

--- a/Makefile
+++ b/Makefile
@@ -316,7 +316,7 @@ test-unit:         $(unit_tests_passing:=.run)
 test-unit-failing: $(unit_tests_failing:=.run)
 
 tests/%.run: tests/% $(llvm_kompiled)
-	$(TEST) run --backend llvm $<
+	$(TEST) interpret --backend llvm $< --output-file /dev/null
 
 # Cross Validation
 
@@ -328,7 +328,7 @@ test-cross:         $(cross_tests_passing:=.cross)
 test-cross-failing: $(cross_tests_failing:=.cross)
 
 tests/%.cross: tests/%.output $(output_compare_kompiled)
-	$(TEST) run --backend output-compare $< --output none > $@
+	$(TEST) interpret --backend output-compare $< --output-file /dev/null > $@
 
 $(cross_tests_passing:=.output): run-tezos.timestamp
 
@@ -337,7 +337,7 @@ run-tezos.timestamp: $(cross_tests_passing) $(cross_tests_passing:=.expanded) $(
 	touch $@
 
 tests/%.expanded: tests/%.address $(contract_expander_kompiled)
-	$(TEST) run --backend contract-expander $< --output none > $@
+	$(TEST) interpret --backend contract-expander $< --output-file /dev/null > $@
 
 $(cross_tests_passing:=.address): fix-address.timestamp
 
@@ -346,10 +346,10 @@ fix-address.timestamp: $(cross_tests_passing) $(cross_tests_passing:=.extracted)
 	touch $@
 
 tests/%.extracted: tests/% $(extractor_kompiled)
-	$(TEST) run --backend extractor $< --output none > $@
+	$(TEST) interpret --backend extractor $< --output-file /dev/null > $@
 
 tests/%.input: tests/% $(input_creator_kompiled)
-	$(TEST) run --backend input-creator $< --output none > $@
+	$(TEST) interpret --backend input-creator $< --output-file /dev/null > $@
 
 # Prove
 

--- a/fix-address.sh
+++ b/fix-address.sh
@@ -21,8 +21,6 @@ extract() {
     python3 "$SCRIPT_DIR/extract-group.py" "$test_file_extracted" "$@"
 }
 
-notif "Fixing Address: $test_file"
-
 TEMP_DIR="$SCRIPT_DIR/.failure"
 
 rm -rf "$TEMP_DIR"

--- a/kmich
+++ b/kmich
@@ -136,7 +136,7 @@ fi
 llvm_krun_args=()
 ! $debug \
     || llvm_krun_args+=(--debug)
-!  echo "$backend_dir" | grep -e contract-expander -e extractor -e input-creator -e output-comare &> /dev/null \
+! echo "$backend_dir" | grep -e contract-expander -e extractor -e input-creator -e output-compare &> /dev/null \
     || llvm_krun_args+=(-c IO '\dv{SortString{}}("on")' String kore)
 
 case "$run_command-$backend" in

--- a/kmich
+++ b/kmich
@@ -68,7 +68,7 @@ if [[ "$run_command" == 'help' ]] || [[ "$run_command" == '--help' ]] ; then
         usage: $0 run       [--backend (llvm|prove|symbolic|contract-expander|extractor|input-creator|output-compare)] <pgm>  <K arg>*
                $0 kast      [--backend (llvm|prove|symbolic|contract-expander|extractor|input-creator|output-compare)] <pgm>  <output format> <K arg>*
                $0 prove     [--backend (prove|symbolic)]                                                               <spec> <def_module>    <K arg>*
-               $0 interpret [--backend (llvm|prove|symbolic|contract-expander|extractor|input-creator|output-compare)] <pgm>  <K arg>*
+               $0 interpret [--backend (llvm|prove|symbolic|contract-expander|extractor|input-creator|output-compare)] <pgm>
 
                $0 [help|--help|version|--version]
 
@@ -134,6 +134,6 @@ case "$run_command-$backend" in
     run-@(llvm|prove|symbolic|contract-expander|extractor|input-creator|output-compare)       ) run_krun  "$@" ;;
     kast-@(llvm|prove|symbolic|contract-expander|extractor|input-creator|output-compare)      ) run_kast  "$@" ;;
     prove-@(prove|symbolic)                                                                   ) run_prove "$@" ;;
-    interpret-@(llvm|prove|symbolic|contract-expander|extractor|input-creator|output-compare) ) run_interpret  "$@" ;;
+    interpret-@(llvm|prove|symbolic|contract-expander|extractor|input-creator|output-compare) ) run_interpret  ;;
     *) $0 help ; fatal "Unknown command on backend: $run_command $backend" ;;
 esac

--- a/kmich
+++ b/kmich
@@ -55,7 +55,7 @@ run_interpret() {
     trap "rm -rf $in_kore $out_kore" INT TERM EXIT
 
     cat "$run_file" | $kompiled_dir/parser_PGM > $in_kore
-    llvm-krun --directory "$kompiled_dir" -c PGM $in_kore Pgm prettyfile --pretty-print
+    llvm-krun --directory "$kompiled_dir" -c PGM $in_kore Pgm korefile --pretty-print
 }
 
 # Main

--- a/kmich
+++ b/kmich
@@ -50,12 +50,16 @@ run_prove() {
 run_interpret() {
     local in_kore out_kore
 
-    in_kore=$(mktemp)
-    out_kore=$(mktemp)
-    trap "rm -rf $in_kore $out_kore" INT TERM EXIT
+    in_kore=$(mktemp $kompiled_dir/in_kore.XXXXXX)
+    out_kore=$(mktemp $kompiled_dir/out_kore.XXXXXX)
+    if $debug; then
+        notif "Input Kore: $in_kore"
+        notif "Output Kore: $out_kore"
+        trap "rm -rf $in_kore $out_kore" INT TERM EXIT
+    fi
 
     cat "$run_file" | $kompiled_dir/parser_PGM > $in_kore
-    llvm-krun --directory "$kompiled_dir" -c PGM $in_kore Pgm korefile --pretty-print
+    llvm-krun --directory "$kompiled_dir" -c PGM $in_kore Pgm korefile --pretty-print "${llvm_krun_args[@]}" "$@"
 }
 
 # Main
@@ -68,7 +72,7 @@ if [[ "$run_command" == 'help' ]] || [[ "$run_command" == '--help' ]] ; then
         usage: $0 run       [--backend (llvm|prove|symbolic|contract-expander|extractor|input-creator|output-compare)] <pgm>  <K arg>*
                $0 kast      [--backend (llvm|prove|symbolic|contract-expander|extractor|input-creator|output-compare)] <pgm>  <output format> <K arg>*
                $0 prove     [--backend (prove|symbolic)]                                                               <spec> <def_module>    <K arg>*
-               $0 interpret [--backend (llvm|prove|symbolic|contract-expander|extractor|input-creator|output-compare)] <pgm>
+               $0 interpret [--backend (llvm|prove|symbolic|contract-expander|extractor|input-creator|output-compare)] <pgm>  <LLVM KRun arg>*
 
                $0 [help|--help|version|--version]
 
@@ -83,6 +87,7 @@ if [[ "$run_command" == 'help' ]] || [[ "$run_command" == '--help' ]] ; then
            Note: <pgm> is a path to a file containing an EVM program/test.
                  <spec> is a K specification to be proved.
                  <K arg> is an argument you want to pass to K.
+                 <LLVM KRun arg> are arguments to pass to llvm-krun.
                  <output format> is the format for Kast to output the term in.
                  <def_module> is the module to take as axioms when doing verification.
     "
@@ -128,12 +133,18 @@ if [[ "$run_file" == '-' ]]; then
 fi
 [[ -f "$run_file" ]] || fatal "File does not exist: $run_file"
 
+llvm_krun_args=()
+! $debug \
+    || llvm_krun_args+=(--debug)
+!  echo "$backend_dir" | grep -e contract-expander -e extractor -e input-creator -e output-comare &> /dev/null \
+    || llvm_krun_args+=(-c IO '\dv{SortString{}}("on")' String kore)
+
 case "$run_command-$backend" in
 
     # Running
-    run-@(llvm|prove|symbolic|contract-expander|extractor|input-creator|output-compare)       ) run_krun  "$@" ;;
-    kast-@(llvm|prove|symbolic|contract-expander|extractor|input-creator|output-compare)      ) run_kast  "$@" ;;
-    prove-@(prove|symbolic)                                                                   ) run_prove "$@" ;;
-    interpret-@(llvm|prove|symbolic|contract-expander|extractor|input-creator|output-compare) ) run_interpret  ;;
+    run-@(llvm|prove|symbolic|contract-expander|extractor|input-creator|output-compare)       ) run_krun       "$@" ;;
+    kast-@(llvm|prove|symbolic|contract-expander|extractor|input-creator|output-compare)      ) run_kast       "$@" ;;
+    prove-@(prove|symbolic)                                                                   ) run_prove      "$@" ;;
+    interpret-@(llvm|prove|symbolic|contract-expander|extractor|input-creator|output-compare) ) run_interpret  "$@" ;;
     *) $0 help ; fatal "Unknown command on backend: $run_command $backend" ;;
 esac

--- a/kmich
+++ b/kmich
@@ -35,7 +35,7 @@ run_krun() {
 run_kast() {
     local output_mode
 
-    output_mode="$1"
+    output_mode="$1" ; shift
     kast --directory "$backend_dir" "$run_file" --output "$output_mode" "$@"
 }
 
@@ -47,6 +47,17 @@ run_prove() {
     kprove --directory "$backend_dir" "$run_file" --def-module "$def_module" "$@"
 }
 
+run_interpret() {
+    local in_kore out_kore
+
+    in_kore=$(mktemp)
+    out_kore=$(mktemp)
+    trap "rm -rf $in_kore $out_kore" INT TERM EXIT
+
+    cat "$run_file" | $kompiled_dir/parser_PGM > $in_kore
+    llvm-krun --directory "$kompiled_dir" -c PGM $in_kore Pgm prettyfile --pretty-print
+}
+
 # Main
 # ----
 
@@ -54,18 +65,20 @@ run_command="$1" ; shift
 
 if [[ "$run_command" == 'help' ]] || [[ "$run_command" == '--help' ]] ; then
     echo "
-        usage: $0 run   [--backend (llvm|prove|symbolic|contract-expander|extractor|input-creator|output-compare)] <pgm>  <K arg>*
-               $0 kast  [--backend (llvm|prove|symbolic|contract-expander|extractor|input-creator|output-compare)] <pgm>  <output format> <K arg>*
-               $0 prove [--backend (prove|symbolic)]                                                      <spec> <def_module>    <K arg>*
+        usage: $0 run       [--backend (llvm|prove|symbolic|contract-expander|extractor|input-creator|output-compare)] <pgm>  <K arg>*
+               $0 kast      [--backend (llvm|prove|symbolic|contract-expander|extractor|input-creator|output-compare)] <pgm>  <output format> <K arg>*
+               $0 prove     [--backend (prove|symbolic)]                                                               <spec> <def_module>    <K arg>*
+               $0 interpret [--backend (llvm|prove|symbolic|contract-expander|extractor|input-creator|output-compare)] <pgm>  <K arg>*
 
                $0 [help|--help|version|--version]
 
-           $0 run       : Run a single EVM program
-           $0 kast      : Parse an EVM program and output it in a supported format
-           $0 prove     : Run an EVM K proof
+           $0 run       : Run a single Michelson program.
+           $0 kast      : Parse a Michelson program and output it in a supported format.
+           $0 prove     : Run a Michelson K proof.
+           $0 interpret : Run a single Michelson program using the fast bison parser.
 
            $0 help    : Display this help message.
-           $0 version : Display the versions of KMich, K, Kore, and Z3 in use.
+           $0 version : Display the versions of KMichelson, K, Kore, and Z3 in use.
 
            Note: <pgm> is a path to a file containing an EVM program/test.
                  <spec> is a K specification to be proved.
@@ -102,6 +115,8 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 backend_dir="${backend_dir:-$defn_dir/$backend}"
+kompiled_dir=$(find $backend_dir -name '*-kompiled')
+[[ -d "$kompiled_dir" ]] || fatal "Could not find single *-kompiled directory in $backend_dir"
 
 # get the run file
 run_file="$1" ; shift
@@ -116,8 +131,9 @@ fi
 case "$run_command-$backend" in
 
     # Running
-    run-@(llvm|prove|symbolic|contract-expander|extractor|input-creator|output-compare)  ) run_krun  "$@" ;;
-    kast-@(llvm|prove|symbolic|contract-expander|extractor|input-creator|output-compare) ) run_kast  "$@" ;;
-    prove-@(prove|symbolic)                                                              ) run_prove "$@" ;;
+    run-@(llvm|prove|symbolic|contract-expander|extractor|input-creator|output-compare)       ) run_krun  "$@" ;;
+    kast-@(llvm|prove|symbolic|contract-expander|extractor|input-creator|output-compare)      ) run_kast  "$@" ;;
+    prove-@(prove|symbolic)                                                                   ) run_prove "$@" ;;
+    interpret-@(llvm|prove|symbolic|contract-expander|extractor|input-creator|output-compare) ) run_interpret  "$@" ;;
     *) $0 help ; fatal "Unknown command on backend: $run_command $backend" ;;
 esac

--- a/run-tezos.sh
+++ b/run-tezos.sh
@@ -21,8 +21,6 @@ extract() {
     python3 "$SCRIPT_DIR/extract-group.py" "$test_file_extracted" "$@"
 }
 
-notif "Running Tezos: $test_file"
-
 TEMP_DIR="$SCRIPT_DIR/.failure"
 
 rm -rf "$TEMP_DIR"

--- a/run-with-tezos.sh
+++ b/run-with-tezos.sh
@@ -49,7 +49,6 @@ command="$1" ; shift
 
 failures='0'
 for test in $(list_files "$@"); do
-    [[ "$status" == '0' ]] || break
     notif "RUNNING: $command on $test"
     if ! $SCRIPT_DIRECTORY/$command.sh "$test"; then
         notif "FAILED: $command on $test"

--- a/run-with-tezos.sh
+++ b/run-with-tezos.sh
@@ -47,17 +47,16 @@ TEST_DIR="$SCRIPT_DIRECTORY/tests/unit"
 
 command="$1" ; shift
 
-status='0'
+failures='0'
 for test in $(list_files "$@"); do
   [[ "$status" == '0' ]] || break
   notif "Running '$command': $test"
-  case "$command" in
-    fix-address) $SCRIPT_DIRECTORY/fix-address.sh "$test" || status="$?" ;;
-    run-tezos)   $SCRIPT_DIRECTORY/run-tezos.sh   "$test" || status="$?" ;;
-    *) fatal "Unknown command: $command"                                 ;;
-  esac
+  if ! $SCRIPT_DIRECTORY/$command.sh "$test"; then
+    notif "FAILED: $command on $test"
+    failures=$((failures + 1))
+  fi
 done
 
 kill -15 "$TEZOS_NODE_PID"
 
-exit "$status"
+exit "$failures"

--- a/run-with-tezos.sh
+++ b/run-with-tezos.sh
@@ -49,12 +49,14 @@ command="$1" ; shift
 
 failures='0'
 for test in $(list_files "$@"); do
-  [[ "$status" == '0' ]] || break
-  notif "Running '$command': $test"
-  if ! $SCRIPT_DIRECTORY/$command.sh "$test"; then
-    notif "FAILED: $command on $test"
-    failures=$((failures + 1))
-  fi
+    [[ "$status" == '0' ]] || break
+    notif "RUNNING: $command on $test"
+    if ! $SCRIPT_DIRECTORY/$command.sh "$test"; then
+        notif "FAILED: $command on $test"
+        failures=$((failures + 1))
+    else
+        notif "PASSED: $command on $test"
+    fi
 done
 
 kill -15 "$TEZOS_NODE_PID"


### PR DESCRIPTION
This is blocked on #39 . It:

-   Generates the bison parser when kompiling the definitions.
-   Fixes some typos throughout the `kmich` script.
-   Adds a command `interpret` to the `kmich` script which uses the generated bison parser and the fast LLVM backend unparser when running programs.
-   Switches the `Makefile` to use `interpret` instead of `run` for a massive speedup in running tests.