### PR TITLE
Fix unused symbol/variable warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,7 +274,7 @@ test: test-unit test-cross test-prove
 
 # Unit
 
-unit_tests         := $(wildcard tests/unit/*.tzt)
+unit_tests         := $(wildcard tests/unit/*.tzt) $(wildcard tests/macros/*.tzt)
 unit_tests_failing := $(shell cat tests/failing.unit)
 unit_tests_passing := $(filter-out $(unit_tests_failing), $(unit_tests))
 
@@ -302,7 +302,7 @@ tests/%.symbolic: tests/% $(symbolic_kompiled)
 
 # Cross Validation
 
-cross_tests         := $(wildcard tests/unit/*.tzt)
+cross_tests         := $(wildcard tests/unit/*.tzt) $(wildcard tests/macros/*.tzt)
 cross_tests_failing := $(shell cat tests/failing.cross)
 cross_tests_passing := $(filter-out $(cross_tests_failing), $(cross_tests))
 

--- a/compat.md
+++ b/compat.md
@@ -34,7 +34,6 @@ Contract Expander
 
 ```k
 module CONTRACT-EXPANDER-SYNTAX
-  imports MICHELSON-MACRO-SYNTAX
   imports UNIT-TEST-SYNTAX
 endmodule
 
@@ -102,7 +101,6 @@ Extractor
 
 ```k
 module EXTRACTOR-SYNTAX
-  imports MICHELSON-MACRO-SYNTAX
   imports UNIT-TEST-SYNTAX
 endmodule
 
@@ -176,7 +174,6 @@ Input Creator
 
 ```k
 module INPUT-CREATOR-SYNTAX
-  imports MICHELSON-MACRO-SYNTAX
   imports UNIT-TEST-SYNTAX
 endmodule
 
@@ -230,7 +227,6 @@ Output Compare
 
 ```k
 module OUTPUT-COMPARE-SYNTAX
-  imports MICHELSON-MACRO-SYNTAX
   imports UNIT-TEST-SYNTAX
   syntax RealOutputGroup ::= "real_output" OutputStack
   syntax Group ::= RealOutputGroup

--- a/compat.md
+++ b/compat.md
@@ -34,6 +34,7 @@ Contract Expander
 
 ```k
 module CONTRACT-EXPANDER-SYNTAX
+  imports MICHELSON-MACRO-SYNTAX
   imports UNIT-TEST-SYNTAX
 endmodule
 
@@ -101,6 +102,7 @@ Extractor
 
 ```k
 module EXTRACTOR-SYNTAX
+  imports MICHELSON-MACRO-SYNTAX
   imports UNIT-TEST-SYNTAX
 endmodule
 
@@ -174,6 +176,7 @@ Input Creator
 
 ```k
 module INPUT-CREATOR-SYNTAX
+  imports MICHELSON-MACRO-SYNTAX
   imports UNIT-TEST-SYNTAX
 endmodule
 
@@ -227,6 +230,7 @@ Output Compare
 
 ```k
 module OUTPUT-COMPARE-SYNTAX
+  imports MICHELSON-MACRO-SYNTAX
   imports UNIT-TEST-SYNTAX
   syntax RealOutputGroup ::= "real_output" OutputStack
   syntax Group ::= RealOutputGroup

--- a/michelson-unparser.md
+++ b/michelson-unparser.md
@@ -5,6 +5,7 @@ requires "michelson/common.md"
 requires "unit-test/syntax.md"
 
 module MICHELSON-UNPARSER
+  imports MICHELSON-MACRO-SYNTAX
   imports MICHELSON-INTERNAL-SYNTAX
   imports MICHELSON-COMMON
   imports UNIT-TEST-COMMON-SYNTAX

--- a/michelson/common.md
+++ b/michelson/common.md
@@ -186,11 +186,11 @@ These include:
 We delegate these datatypes validations to their own functions.
 
 ```k
-  rule #MichelineToNative(S:String, key_hash _,  KnownAddrs, BigMaps) => #ParseKeyHash(S)
-  rule #MichelineToNative(S:String, address _,   KnownAddrs, BigMaps) => #ParseAddress(S)
-  rule #MichelineToNative(S:String, key _,       KnownAddrs, BigMaps) => #ParseKey(S)
-  rule #MichelineToNative(S:String, signature _, KnownAddrs, BigMaps) => #ParseSignature(S)
-  rule #MichelineToNative(S:String, timestamp _, KnownAddrs, BigMaps) => #ParseTimestamp(S)
+  rule #MichelineToNative(S:String, key_hash _,  _KnownAddrs, _BigMaps) => #ParseKeyHash(S)
+  rule #MichelineToNative(S:String, address _,   _KnownAddrs, _BigMaps) => #ParseAddress(S)
+  rule #MichelineToNative(S:String, key _,       _KnownAddrs, _BigMaps) => #ParseKey(S)
+  rule #MichelineToNative(S:String, signature _, _KnownAddrs, _BigMaps) => #ParseSignature(S)
+  rule #MichelineToNative(S:String, timestamp _, _KnownAddrs, _BigMaps) => #ParseTimestamp(S)
 ```
 
 A simple hook to return the Unix epoch representation of a timestamp passed to
@@ -227,7 +227,7 @@ Note that timestamps have an optimized form based on integers.
 We convert that form here.
 
 ```k
-  rule #MichelineToNative(I:Int, timestamp _, KnownAddrs, BigMaps) => #Timestamp(I)
+  rule #MichelineToNative(I:Int, timestamp _, _KnownAddrs, _BigMaps) => #Timestamp(I)
 ```
 
 ### Converting Simple Datatypes
@@ -235,34 +235,34 @@ We convert that form here.
 A ChainId is simply a specially tagged MBytes.
 
 ```k
-  rule #MichelineToNative(H:MBytes, chain_id _, KnownAddrs, BigMaps) => #ChainId(H)
+  rule #MichelineToNative(H:MBytes, chain_id _, _KnownAddrs, _BigMaps) => #ChainId(H)
 ```
 
 An int can simply be represented directly as a K int. Nats get an additional
 sanity check to avoid negative nats.
 
 ```k
-  rule #MichelineToNative(I:Int, int _, KnownAddrs, BigMaps) => I
-  rule #MichelineToNative(I:Int, nat _, KnownAddrs, BigMaps) => I requires I >=Int 0
+  rule #MichelineToNative(I:Int, int _, _KnownAddrs, _BigMaps) => I
+  rule #MichelineToNative(I:Int, nat _, _KnownAddrs, _BigMaps) => I requires I >=Int 0
 ```
 
 Strings, like ints, represent themselves.
 
 ```k
-  rule #MichelineToNative(S:String, string _, KnownAddrs, BigMaps) => S
+  rule #MichelineToNative(S:String, string _, _KnownAddrs, _BigMaps) => S
 ```
 
 MBytes conversion is done by the function rule.
 
 ```k
-  rule #MichelineToNative(B:MBytes, bytes _, KnownAddrs, BigMaps) => B
+  rule #MichelineToNative(B:MBytes, bytes _, _KnownAddrs, _BigMaps) => B
 ```
 
 Mutez is simply a specially tagged int - we also sanity check the int to ensure
 that it is in bounds.
 
 ```k
-  rule #MichelineToNative(I:Int, mutez _, KnownAddrs, BigMaps) => #Mutez(I) requires #IsLegalMutezValue(I)
+  rule #MichelineToNative(I:Int, mutez _, _KnownAddrs, _BigMaps) => #Mutez(I) requires #IsLegalMutezValue(I)
 ```
 
 K's function expansion step has already handled converting Michelsons
@@ -270,13 +270,13 @@ K's function expansion step has already handled converting Michelsons
 special with them here.
 
 ```k
-  rule #MichelineToNative(B:Bool, bool _, KnownAddrs, BigMaps) => B
+  rule #MichelineToNative(B:Bool, bool _, _KnownAddrs, _BigMaps) => B
 ```
 
 The Unit token represents itself.
 
 ```k
-  rule #MichelineToNative(Unit, unit _, KnownAddrs, BigMaps) => Unit
+  rule #MichelineToNative(Unit, unit _, _KnownAddrs, _BigMaps) => Unit
 ```
 
 ### Converting Complex Datatypes
@@ -288,7 +288,7 @@ We recursively convert the contents of pairs, ors and options, if applicable.
        Pair #MichelineToNative(A, T1, KnownAddrs, BigMaps) #MichelineToNative(B, T2, KnownAddrs, BigMaps)
 
   rule #MichelineToNative(Some V, option _ T, KnownAddrs, BigMaps) => Some #MichelineToNative(V, T, KnownAddrs, BigMaps)
-  rule #MichelineToNative(None, option _:AnnotationList _, KnownAddrs, BigMaps) => None
+  rule #MichelineToNative(None, option _:AnnotationList _, _KnownAddrs, _BigMaps) => None
 
   rule #MichelineToNative(Left V, or _:AnnotationList TL:Type _:Type,  KnownAddrs, BigMaps) => Left #MichelineToNative(V, TL, KnownAddrs, BigMaps)
   rule #MichelineToNative(Right V, or _:AnnotationList _:Type TR:Type, KnownAddrs, BigMaps) => Right #MichelineToNative(V, TR, KnownAddrs, BigMaps)
@@ -297,7 +297,7 @@ We recursively convert the contents of pairs, ors and options, if applicable.
 We wrap Lambdas appropriately and save their type information.  Note that we do *not* recurse into the Block.
 
 ```k
-  rule #MichelineToNative(B:Block, lambda _:AnnotationList T1 T2, KnownAddrs, BigMaps) => #Lambda(T1, T2, B)
+  rule #MichelineToNative(B:Block, lambda _:AnnotationList T1 T2, _KnownAddrs, _BigMaps) => #Lambda(T1, T2, B)
 ```
 
 Collections are converted one element at a time. We need to handle the cases of
@@ -305,7 +305,7 @@ Collections are converted one element at a time. We need to handle the cases of
 element list, and another embedded list.
 
 ```k
-  rule #MichelineToNative({ }, list _ _, KnownAddrs, BigMaps) => .List
+  rule #MichelineToNative({ }, list _ _, _KnownAddrs, _BigMaps) => .List
   rule #MichelineToNative({ D1:Data }, list _ T, KnownAddrs, BigMaps) => ListItem(#MichelineToNative(D1, T, KnownAddrs, BigMaps))
   rule #MichelineToNative({ D1 ; DL:DataList }, list _ T, KnownAddrs, BigMaps) => #MichelineToNative(D1 ; DL, list .AnnotationList T, KnownAddrs, BigMaps)
 
@@ -320,7 +320,7 @@ Sets are handled essentially the same way as lists, with the same caveat about
 needing to handle 3 cases (0-Size sets, 1-Size sets, and otherwise).
 
 ```k
-  rule #MichelineToNative({ }, set _ _, KnownAddrs, BigMaps) => .Set
+  rule #MichelineToNative({ }, set _ _, _KnownAddrs, _BigMaps) => .Set
   rule #MichelineToNative({ D:Data }, set _ T, KnownAddrs, BigMaps) => SetItem(#MichelineToNative(D, T, KnownAddrs, BigMaps))
   rule #MichelineToNative({ D1 ; DL:DataList }, set _ T, KnownAddrs, BigMaps) => #MichelineToNative(D1 ; DL, set .AnnotationList T, KnownAddrs, BigMaps)
 
@@ -336,7 +336,7 @@ handle the case of size 1 maps separately. Note that, internally, no difference
 exists between maps and `big_map`s in K-Michelson.
 
 ```k
-  rule #MichelineToNative({ }, map _ _ _, KnownAddrs, BigMaps) => .Map
+  rule #MichelineToNative({ }, map _ _ _, _KnownAddrs, _BigMaps) => .Map
   rule #MichelineToNative({ M:MapEntryList }, map _:AnnotationList KT VT, KnownAddrs, BigMaps) =>
        #MichelineToNative(M, map .AnnotationList KT VT, KnownAddrs, BigMaps)
 
@@ -346,7 +346,7 @@ exists between maps and `big_map`s in K-Michelson.
   rule #MichelineToNative(Elt K V, map _:AnnotationList KT VT, KnownAddrs, BigMaps) =>
        #MichelineToNative(K, KT, KnownAddrs, BigMaps) |-> #MichelineToNative(V, VT, KnownAddrs, BigMaps)
 
-  rule #MichelineToNative({ }, big_map _:AnnotationList K V, KnownAddrs, BigMaps) => .Map
+  rule #MichelineToNative({ }, big_map _:AnnotationList _K _V, _KnownAddrs, _BigMaps) => .Map
 
   rule #MichelineToNative({ M:MapEntryList }, big_map _:AnnotationList K V, KnownAddrs, BigMaps) =>
        #MichelineToNative({ M:MapEntryList }, map .AnnotationList K V, KnownAddrs, BigMaps)  // We handle big_map literals as maps.
@@ -357,7 +357,7 @@ for convenience, we do not enforce that this address exists in the
 `other_contracts` map!
 
 ```k
-  rule #MichelineToNative(S:String, contract _ T, KnownAddrs, BigMaps) => #Contract(#ParseAddress(S), T)
+  rule #MichelineToNative(S:String, contract _ T, _KnownAddrs, _BigMaps) => #Contract(#ParseAddress(S), T)
 
   rule #MichelineToNative(#Typed(D, T), T, KnownAddrs, BigMaps) => #MichelineToNative(D, T, KnownAddrs, BigMaps)
 ```
@@ -412,7 +412,7 @@ We extract a `big_map` by index from the bigmaps map. Note that these have
 already been converted to K-internal form, so there is no need to recurse here.
 
 ```k
-  rule #MichelineToNative(I:Int, big_map _:AnnotationList K V, KnownAddrs, BigMaps) => {BigMaps[I]}:>Data
+  rule #MichelineToNative(I:Int, big_map _:AnnotationList _K _V, _KnownAddrs, BigMaps) => {BigMaps[I]}:>Data
 ```
 
 ```k

--- a/michelson/michelson.md
+++ b/michelson/michelson.md
@@ -835,12 +835,6 @@ Sum types are similar to options.
 
   rule <k> IF_LEFT A BT BF => #HandleAnnotations(A) ~> BF ... </k>
        <stack> Right V => V ... </stack>
-
-  rule <k> IF_RIGHT A BT BF => #HandleAnnotations(A) ~> BT ... </k>
-       <stack> Right V => V ... </stack>
-
-  rule <k> IF_RIGHT A BT BF => #HandleAnnotations(A) ~> BF ... </k>
-       <stack> Left V => V ... </stack>
 ```
 
 Lists are somewhat nontrivial in that we need to keep track of typing

--- a/michelson/syntax.md
+++ b/michelson/syntax.md
@@ -287,67 +287,6 @@ set used for debugging purposes.
   syntax Instruction ::= TRACE(String)
 ```
 
-We list Macros separately, although in practice macros should not exist by this point (since the external parser eliminates them), we keep them in the grammar for future work.
-
-```k
-  syntax Macro
-  syntax Instruction ::= Macro
-
-  syntax DIPMacro ::= r"DII+P" [token]
-  syntax DUPMacro ::= r"DUU+P" [token]
-  syntax PairMacro ::= r"P[AIP]+R" [token] // This regex needs to be far more complex, but not sure how much K actually supports. P(\left=A|P(\left)(\right))(\right=I|P(\left)(\right))R
-  syntax UnpairMacro ::= r"UNP[AIP]+R" [token] // Same as above. UNP(\left=A|P(\left)(\right))(\right=I|P(\left)(\right))R
-  syntax CDARMacro ::= r"C[A,D]{2,}R" [token]
-  syntax SetCDARMacro ::= r"SET_C[AD]+R" [token]
-
-  syntax Macro ::= DIPMacro AnnotationList Block
-  syntax Macro ::= DUPMacro AnnotationList
-  syntax Macro ::= PairMacro AnnotationList
-  syntax Macro ::= UnpairMacro AnnotationList
-  syntax Macro ::= CDARMacro AnnotationList
-  syntax Macro ::= SetCDARMacro AnnotationList
-
-  syntax Macro ::= "CMPEQ" AnnotationList
-  syntax Macro ::= "CMPNEQ" AnnotationList
-  syntax Macro ::= "CMPLT" AnnotationList
-  syntax Macro ::= "CMPGT" AnnotationList
-  syntax Macro ::= "CMPLE" AnnotationList
-  syntax Macro ::= "CMPGE" AnnotationList
-  syntax Macro ::= "IFEQ" AnnotationList Block Block
-  syntax Macro ::= "IFNEQ" AnnotationList Block Block
-  syntax Macro ::= "IFLT" AnnotationList Block Block
-  syntax Macro ::= "IFGT" AnnotationList Block Block
-  syntax Macro ::= "IFLE" AnnotationList Block Block
-  syntax Macro ::= "IFGE" AnnotationList Block Block
-  syntax Macro ::= "IFCMPEQ" AnnotationList Block Block
-  syntax Macro ::= "IFCMPNEQ" AnnotationList Block Block
-  syntax Macro ::= "IFCMPLT" AnnotationList Block Block
-  syntax Macro ::= "IFCMPGT" AnnotationList Block Block
-  syntax Macro ::= "IFCMPLE" AnnotationList Block Block
-  syntax Macro ::= "IFCMPGE" AnnotationList Block Block
-  syntax Macro ::= "FAIL" AnnotationList
-  syntax Macro ::= "ASSERT" AnnotationList
-  syntax Macro ::= "ASSERT_EQ" AnnotationList
-  syntax Macro ::= "ASSERT_NEQ" AnnotationList
-  syntax Macro ::= "ASSERT_LT" AnnotationList
-  syntax Macro ::= "ASSERT_LE" AnnotationList
-  syntax Macro ::= "ASSERT_GT" AnnotationList
-  syntax Macro ::= "ASSERT_GE" AnnotationList
-  syntax Macro ::= "ASSERT_CMPEQ" AnnotationList
-  syntax Macro ::= "ASSERT_CMPNEQ" AnnotationList
-  syntax Macro ::= "ASSERT_CMPLT" AnnotationList
-  syntax Macro ::= "ASSERT_CMPLE" AnnotationList
-  syntax Macro ::= "ASSERT_CMPGT" AnnotationList
-  syntax Macro ::= "ASSERT_CMPGE" AnnotationList
-  syntax Macro ::= "ASSERT_NONE" AnnotationList
-  syntax Macro ::= "ASSERT_SOME" AnnotationList
-  syntax Macro ::= "ASSERT_LEFT" AnnotationList
-  syntax Macro ::= "ASSERT_RIGHT" AnnotationList
-  syntax Macro ::= "IF_SOME" AnnotationList Block Block
-  syntax Macro ::= "IF_RIGHT" AnnotationList Block Block
-  syntax Macro ::= "SET_CAR" AnnotationList
-  syntax Macro ::= "SET_CDR" AnnotationList
-```
 
 Here we specify the different formats a Michelson Contract may take.  These will be converted to the first format (`Code ; Storage ; Parameter ;`) by macros immediately after parsing.
 
@@ -446,5 +385,73 @@ present for an execution to work.
 
 ```k
   syntax Pgm ::= Groups
+endmodule
+```
+
+We list Macros separately, although in practice macros should not exist by this
+point (since the external parser eliminates them).
+We keep them in the grammar for future work.
+
+```k
+module MICHELSON-MACRO-SYNTAX
+  imports MICHELSON-SYNTAX
+
+  syntax Macro
+  syntax Instruction ::= Macro
+
+  syntax DIPMacro ::= r"DII+P" [token]
+  syntax DUPMacro ::= r"DUU+P" [token]
+  syntax PairMacro ::= r"P[AIP]+R" [token] // This regex needs to be far more complex, but not sure how much K actually supports. P(\left=A|P(\left)(\right))(\right=I|P(\left)(\right))R
+  syntax UnpairMacro ::= r"UNP[AIP]+R" [token] // Same as above. UNP(\left=A|P(\left)(\right))(\right=I|P(\left)(\right))R
+  syntax CDARMacro ::= r"C[A,D]{2,}R" [token]
+  syntax SetCDARMacro ::= r"SET_C[AD]+R" [token]
+
+  syntax Macro ::= DIPMacro AnnotationList Block
+  syntax Macro ::= DUPMacro AnnotationList
+  syntax Macro ::= PairMacro AnnotationList
+  syntax Macro ::= UnpairMacro AnnotationList
+  syntax Macro ::= CDARMacro AnnotationList
+  syntax Macro ::= SetCDARMacro AnnotationList
+
+  syntax Macro ::= "CMPEQ" AnnotationList
+  syntax Macro ::= "CMPNEQ" AnnotationList
+  syntax Macro ::= "CMPLT" AnnotationList
+  syntax Macro ::= "CMPGT" AnnotationList
+  syntax Macro ::= "CMPLE" AnnotationList
+  syntax Macro ::= "CMPGE" AnnotationList
+  syntax Macro ::= "IFEQ" AnnotationList Block Block
+  syntax Macro ::= "IFNEQ" AnnotationList Block Block
+  syntax Macro ::= "IFLT" AnnotationList Block Block
+  syntax Macro ::= "IFGT" AnnotationList Block Block
+  syntax Macro ::= "IFLE" AnnotationList Block Block
+  syntax Macro ::= "IFGE" AnnotationList Block Block
+  syntax Macro ::= "IFCMPEQ" AnnotationList Block Block
+  syntax Macro ::= "IFCMPNEQ" AnnotationList Block Block
+  syntax Macro ::= "IFCMPLT" AnnotationList Block Block
+  syntax Macro ::= "IFCMPGT" AnnotationList Block Block
+  syntax Macro ::= "IFCMPLE" AnnotationList Block Block
+  syntax Macro ::= "IFCMPGE" AnnotationList Block Block
+  syntax Macro ::= "FAIL" AnnotationList
+  syntax Macro ::= "ASSERT" AnnotationList
+  syntax Macro ::= "ASSERT_EQ" AnnotationList
+  syntax Macro ::= "ASSERT_NEQ" AnnotationList
+  syntax Macro ::= "ASSERT_LT" AnnotationList
+  syntax Macro ::= "ASSERT_LE" AnnotationList
+  syntax Macro ::= "ASSERT_GT" AnnotationList
+  syntax Macro ::= "ASSERT_GE" AnnotationList
+  syntax Macro ::= "ASSERT_CMPEQ" AnnotationList
+  syntax Macro ::= "ASSERT_CMPNEQ" AnnotationList
+  syntax Macro ::= "ASSERT_CMPLT" AnnotationList
+  syntax Macro ::= "ASSERT_CMPLE" AnnotationList
+  syntax Macro ::= "ASSERT_CMPGT" AnnotationList
+  syntax Macro ::= "ASSERT_CMPGE" AnnotationList
+  syntax Macro ::= "ASSERT_NONE" AnnotationList
+  syntax Macro ::= "ASSERT_SOME" AnnotationList
+  syntax Macro ::= "ASSERT_LEFT" AnnotationList
+  syntax Macro ::= "ASSERT_RIGHT" AnnotationList
+  syntax Macro ::= "IF_SOME" AnnotationList Block Block
+  syntax Macro ::= "IF_RIGHT" AnnotationList Block Block
+  syntax Macro ::= "SET_CAR" AnnotationList
+  syntax Macro ::= "SET_CDR" AnnotationList
 endmodule
 ```

--- a/michelson/syntax.md
+++ b/michelson/syntax.md
@@ -450,8 +450,13 @@ module MICHELSON-MACRO-SYNTAX
   syntax Macro ::= "ASSERT_SOME" AnnotationList
   syntax Macro ::= "ASSERT_LEFT" AnnotationList
   syntax Macro ::= "ASSERT_RIGHT" AnnotationList
-  syntax Macro ::= "IF_SOME" AnnotationList Block Block
-  syntax Macro ::= "IF_RIGHT" AnnotationList Block Block
+
+  syntax Instruction ::= "IF_SOME" AnnotationList Block Block
+  rule IF_SOME Annots BS BN => IF_NONE Annots BN BS [anywhere]
+
+  syntax Instruction ::= "IF_RIGHT" AnnotationList Block Block
+  rule IF_RIGHT Annots BL BR => IF_LEFT Annots BR BL [anywhere] 
+  
   syntax Macro ::= "SET_CAR" AnnotationList
   syntax Macro ::= "SET_CDR" AnnotationList
 endmodule

--- a/michelson/syntax.md
+++ b/michelson/syntax.md
@@ -3,6 +3,7 @@ This module declares the syntax of a K-Michelson input file.  In particular, it 
 ```k
 module MICHELSON-SYNTAX
   imports MICHELSON-COMMON-SYNTAX
+  imports MICHELSON-MACRO-SYNTAX
 
   syntax TypeAnnotation ::= r":([_a-zA-Z][_0-9a-zA-Z\\.]*)?" [token]
   syntax VariableAnnotation ::= r"@(%|%%|[_a-zA-Z][_0-9a-zA-Z\\.]*)?" [token]
@@ -394,7 +395,7 @@ We keep them in the grammar for future work.
 
 ```k
 module MICHELSON-MACRO-SYNTAX
-  imports MICHELSON-SYNTAX
+  imports MICHELSON-COMMON-SYNTAX
 
   syntax Macro
   syntax Instruction ::= Macro

--- a/michelson/types.md
+++ b/michelson/types.md
@@ -28,9 +28,8 @@ Type Check Constructors
   syntax TypedInstructionList ::= TypedInstruction ";" TypedInstructionList | TypedInstruction
                                 | #Remaining(DataList)
 
-  syntax TypeError ::= #InvalidTypeForInstruction(Instruction, TypeSeq)
+  syntax TypeError ::= #InvalidTypeForInstruction(Instruction, TypeSeq) [unused]
                      | #IncompatibleTypesForBranch(Instruction, TypeInput, TypeInput)
-                     | #UnexpectedMacro(Macro, TypeSeq)
                      | "#UnexpectedFailureType"
                      | "#InternalError"
                      | #MistypedData(Data, Type)
@@ -303,7 +302,7 @@ Type Checking Rules
   rule #TypeInstruction(_, (EMPTY_MAP _ KT VT) #as I, Ts) => #TI(I, Ts -> map .AnnotationList KT VT ; Ts)
   rule #TypeInstruction(_, (EMPTY_BIG_MAP _ KT VT) #as I, Ts) => #TI(I, Ts -> big_map .AnnotationList KT VT ; Ts)
 
- // rule #TypeInstruction(_, I, T) => #TI(I, #InvalidTypeForInstruction(I, T)) [owise]
+  // rule #TypeInstruction(_, I, T) => #TI(I, #InvalidTypeForInstruction(I, T)) [owise]
 
   syntax TypedInstruction ::= #MapAux(Instruction, TypedInstruction, TypeSeq) [function, functional]
   rule #MapAux(MAP _ _, (#TI(_, _ -> N ; Ts) #as B), (list _ _ ; Ts) #as OS) => #TI(MAP .AnnotationList { #Exec(B) }, OS -> (list .AnnotationList N) ; Ts)
@@ -541,10 +540,10 @@ Type Checking Rules
   rule #TypeInstruction(_, (SENDER _) #as I, OS) => #TI(I, OS -> (address .AnnotationList) ; OS)
   rule #TypeInstruction(_, (ADDRESS _) #as I, (contract _ _ ; Ts) #as OS) => #TI(I, OS -> (address .AnnotationList) ; Ts)
 
-  rule #TypeInstruction(C, (TRACE(S)) #as I, OS) => #TI(I, OS -> OS)
-  rule #TypeInstruction(C, STOP       #as I, OS) => #TI(I, OS -> OS)
-  rule #TypeInstruction(C, PAUSE      #as I, OS) => #TI(I, OS -> OS)
-  rule #TypeInstruction(C, (PAUSE(S)) #as I, OS) => #TI(I, OS -> OS)
+  rule #TypeInstruction(_, (TRACE(_)) #as I, OS) => #TI(I, OS -> OS)
+  rule #TypeInstruction(_, STOP       #as I, OS) => #TI(I, OS -> OS)
+  rule #TypeInstruction(_, PAUSE      #as I, OS) => #TI(I, OS -> OS)
+  rule #TypeInstruction(_, (PAUSE(_)) #as I, OS) => #TI(I, OS -> OS)
 
   syntax TypedInstruction ::= #CreateContractAux(Instruction, TypedInstruction, TypeSeq) [function, functional]
 

--- a/michelson/types.md
+++ b/michelson/types.md
@@ -32,24 +32,23 @@ Type Check Constructors
                      | #IncompatibleTypesForBranch(Instruction, TypeInput, TypeInput)
                      | #UnexpectedMacro(Macro, TypeSeq)
                      | "#UnexpectedFailureType"
-
-  syntax TypeError ::= "#InternalError"
-  syntax TypeError ::= #MistypedData(Data, Type)
-  syntax TypeError ::= #MistypedInnerData(List)
-  syntax TypeError ::= #IllTypedLambda(TypedInstruction, Type, Type)
-  syntax TypeError ::= #SequenceError(TypeInput)
-  syntax TypeError ::= #CreateContractError(TypedInstruction, TypeSeq)
-  syntax TypeError ::= #DIPError(TypedInstruction, TypeSeq)
-  syntax TypeError ::= #InvalidDIP(Int)
-  syntax TypeError ::= #LambdaError(Instruction, TypedInstruction, TypeSeq)
-  syntax TypeError ::= #IllTypedLambdaInst(TypedInstruction, Type, Type, Bool, Bool)
-  syntax TypeError ::= #InvalidPostIterationStack(Instruction, TypeSeq, TypeSeq)
-  syntax TypeError ::= #IllegalBranchInstruction(Instruction) // Internal error.
-  syntax TypeError ::= #MultipleTypeErrors(TypeError, TypeError)
-  syntax TypeError ::= #InvalidPush(Instruction, TypeError)
-  syntax TypeError ::= #InvalidDropCount(TypeSeq, Int)
-  syntax TypeError ::= #InvalidDigCount(TypeSeq, Int)
-  syntax TypeError ::= #InvalidDugCount(TypeSeq, Int)
+                     | "#InternalError"
+                     | #MistypedData(Data, Type)
+                     | #MistypedInnerData(List)
+                     | #IllTypedLambda(TypedInstruction, Type, Type)
+                     | #SequenceError(TypeInput)
+                     | #CreateContractError(TypedInstruction, TypeSeq)
+                     | #DIPError(TypedInstruction, TypeSeq)
+                     | #InvalidDIP(Int)
+                     | #LambdaError(Instruction, TypedInstruction, TypeSeq)
+                     | #IllTypedLambdaInst(TypedInstruction, Type, Type, Bool, Bool)
+                     | #InvalidPostIterationStack(Instruction, TypeSeq, TypeSeq)
+                     | #IllegalBranchInstruction(Instruction) // Internal error.
+                     | #MultipleTypeErrors(TypeError, TypeError)
+                     | #InvalidPush(Instruction, TypeError)
+                     | #InvalidDropCount(TypeSeq, Int)
+                     | #InvalidDigCount(TypeSeq, Int)
+                     | #InvalidDugCount(TypeSeq, Int)
 
   syntax Instruction ::= #InvalidBranchInstruction(Instruction)
 

--- a/michelson/types.md
+++ b/michelson/types.md
@@ -73,13 +73,13 @@ Type Checking Rules
 
   syntax TypeResult ::= #MergeResults(TypeSeq, TypeResult) [function, functional]
   rule #MergeResults(_, E:TypeError) => E
-  rule #MergeResults(TS, #ContractFailed) => #ContractFailed
+  rule #MergeResults(_, #ContractFailed) => #ContractFailed
   rule #MergeResults(TS, _ -> TD) => TS -> TD
 
   syntax MaybeData ::= #TypeData(TypeContext, Data, Type) [function, functional]
   syntax MaybeData ::= #CheckInnerData(Data, Type, List) [function, functional]
 
-  rule #TypeData(C, D, T) => #MistypedData(D, T) [owise]
+  rule #TypeData(_, D, T) => #MistypedData(D, T) [owise]
 
   rule #TypeData(_, Unit, unit _) => #Typed(Unit, unit .AnnotationList)
 
@@ -101,16 +101,16 @@ Type Checking Rules
   rule #TypeData(C, (Pair VL VR) #as D, (pair _ TL TR) #as T) => #CheckInnerData(D, T, ListItem(#TypeData(C, VL, TL)) ListItem(#TypeData(C, VR, TR)))
 
   rule #TypeData(C, (Some V) #as D, (option _ TI) #as T) => #CheckInnerData(D, T, ListItem(#TypeData(C, V, TI)))
-  rule #TypeData(C, None #as D, (option _ TI) #as T) => #Typed(D, T)
+  rule #TypeData(_, None     #as D, (option _  _) #as T) => #Typed(D, T)
 
   rule #TypeData(C, (Left V) #as D, (or _ TI _) #as T) => #CheckInnerData(D, T, ListItem(#TypeData(C, V, TI)))
   rule #TypeData(C, (Right V) #as D, (or _ _ TI) #as T) => #CheckInnerData(D, T, ListItem(#TypeData(C, V, TI)))
 
-  rule #TypeData(C, D:String, (contract _ _) #as T) => #Typed(D, T)
+  rule #TypeData(_, D:String, (contract _ _) #as T) => #Typed(D, T)
 
   syntax Bool ::= #AllWellTyped(List) [function, functional]
   rule #AllWellTyped(ListItem(#Typed(_, _)) L) => #AllWellTyped(L)
-  rule #AllWellTyped(ListItem(_) L) => false [owise]
+  rule #AllWellTyped(ListItem(_) _) => false [owise]
   rule #AllWellTyped(.List) => true
 
 
@@ -127,10 +127,10 @@ Type Checking Rules
   rule #TypeLambdaAux(T, T1, T2) => #IllTypedLambda(T, T1, T2) [owise]
 
 
-  rule #TypeData(C, { } #as D, (list _ _) #as T) => #Typed(D, T)
-  rule #TypeData(C, { } #as D, (set _ _) #as T) => #Typed(D, T)
-  rule #TypeData(C, { } #as D, (map _ _ _) #as T) => #Typed(D, T)
-  rule #TypeData(C, { } #as D, (big_map _ _ _) #as T) => #Typed(D, T)
+  rule #TypeData(_, { } #as D, (list _ _) #as T) => #Typed(D, T)
+  rule #TypeData(_, { } #as D, (set _ _) #as T) => #Typed(D, T)
+  rule #TypeData(_, { } #as D, (map _ _ _) #as T) => #Typed(D, T)
+  rule #TypeData(_, { } #as D, (big_map _ _ _) #as T) => #Typed(D, T)
 
   syntax List ::= #TypeCheckListElements(TypeContext, DataList, Type) [function, functional]
 
@@ -147,16 +147,16 @@ Type Checking Rules
   rule #TypeData(C, { DL } #as D, (map _ KT VT) #as T) => #CheckInnerData(D, T, #TypeCheckMapElements(C, DL, KT, VT))
   rule #TypeData(C, { DL } #as D, (big_map _ KT VT) #as T) => #CheckInnerData(D, T, #TypeCheckMapElements(C, DL, KT, VT))
 
-  rule #TypeData(C, I:Int, (big_map _ KT VT) #as T) => #Typed(I, T)
+  rule #TypeData(_, I:Int, (big_map _ _ _) #as T) => #Typed(I, T)
 
-  rule #TypeData(C, (Create_contract(_, _, _, _, _) #as D), (operation _) #as T) => #Typed(D, T)
-  rule #TypeData(C, (Transfer_tokens(_, _, _, _) #as D), (operation _) #as T) => #Typed(D, T)
-  rule #TypeData(C, (Set_delegate(_, _) #as D), (operation _) #as T) => #Typed(D, T)
+  rule #TypeData(_, (Create_contract(_, _, _, _, _) #as D), (operation _) #as T) => #Typed(D, T)
+  rule #TypeData(_, (Transfer_tokens(_, _, _, _) #as D), (operation _) #as T) => #Typed(D, T)
+  rule #TypeData(_, (Set_delegate(_, _) #as D), (operation _) #as T) => #Typed(D, T)
 
-  rule #TypeInstruction(C, { }, TS) => #TI({ }, TS -> TS)
+  rule #TypeInstruction(_, { }, TS) => #TI({ }, TS -> TS)
   rule #TypeInstruction(C, { Is:DataList }, TS) => #fun(#TIs(Is2, TR) => #TI({ #Exec(Is2) }, TR))(#TypeInstructions(C, Is, TS))
 
-  rule #TypeInstructions(C, Is, TE:TypeError) => #TIs(#Remaining(Is), TE)
+  rule #TypeInstructions(_, Is, TE:TypeError) => #TIs(#Remaining(Is), TE)
 
 
   rule #TypeInstructions(_, Is, TR) => #TIs(#Remaining(Is), #SequenceError(TR)) [owise]
@@ -167,8 +167,8 @@ Type Checking Rules
 
   rule #TypeInstructions(C, I:Instruction, TS:TypeSeq) => #fun(#TI(I2, TR) => #TIs(#TI(I2, TR), TR))(#TypeInstruction(C, I, TS))
 
-  rule #TypeInstruction(C, (DROP _) #as I, (_ ; Rs) #as T1) => #TI(I, T1 -> Rs)
-  rule #TypeInstruction(C, (DROP _ N) #as I, T1) => #TI(I, T1 -> #DropFirst(T1, N))
+  rule #TypeInstruction(_, (DROP _) #as I, (_ ; Rs) #as T1) => #TI(I, T1 -> Rs)
+  rule #TypeInstruction(_, (DROP _ N) #as I, T1) => #TI(I, T1 -> #DropFirst(T1, N))
 
   syntax TypeInput ::= #DropFirst(TypeSeq, Int) [function, functional]
 
@@ -177,7 +177,7 @@ Type Checking Rules
   rule #DropFirst(_ ; TS, I) => #DropFirst(TS, I -Int 1) requires I >Int 0
 
 
-  rule #TypeInstruction(C, (DIG _ N) #as I, T1) => #TI(I, T1 -> #DigType(T1, N))
+  rule #TypeInstruction(_, (DIG _ N) #as I, T1) => #TI(I, T1 -> #DigType(T1, N))
 
 
   syntax TypeInput ::= #DigType(TypeSeq, Int) [function, functional]
@@ -193,18 +193,18 @@ Type Checking Rules
   rule #GetTypeN(_, _) => #NoType [owise]
 
   syntax TypeSeq ::= #RemoveN(TypeSeq, Int) [function, functional]
-  rule #RemoveN(T1 ; Ts, 0) => Ts
+  rule #RemoveN(_  ; Ts, 0) => Ts
   rule #RemoveN(T1 ; Ts, I) => T1 ; #RemoveN(Ts, I -Int 1) requires I >Int 0
-  rule #RemoveN(Ts, I) => Ts [owise] // This rule is unreachable.
+  rule #RemoveN(Ts, _) => Ts [owise] // This rule is unreachable.
 
   syntax TypeSeq ::= #RemoveFirstN(TypeSeq, Int) [function, functional]
   rule #RemoveFirstN(Ts, 0) => Ts
-  rule #RemoveFirstN(T1 ; Ts, I) => #RemoveFirstN(Ts, I -Int 1) requires I >Int 0
-  rule #RemoveFirstN(Ts, I) => Ts [owise] // This rule is unreachable.
+  rule #RemoveFirstN(_ ; Ts, I) => #RemoveFirstN(Ts, I -Int 1) requires I >Int 0
+  rule #RemoveFirstN(Ts, _) => Ts [owise] // This rule is unreachable.
 
 
 
-  rule #TypeInstruction(C, (DUG _ N) #as I, T1) => #TI(I, T1 -> #DoDug(T1, N))
+  rule #TypeInstruction(_, (DUG _ N) #as I, T1) => #TI(I, T1 -> #DoDug(T1, N))
 
   syntax Int ::= #LengthTypeSeq(TypeSeq) [function, functional]
   rule #LengthTypeSeq(.TypeSeq) => 0
@@ -217,12 +217,12 @@ Type Checking Rules
   rule #DoDug(T1 ; TS, I) => #DoDugAux(TS, I, T1)
 
   syntax TypeSeq ::= #DoDugAux(TypeSeq, Int, Type) [function]
-  rule #DoDugAux(_, I, T) => .TypeSeq requires I <Int 0 // This pattern is unreachable.
+  rule #DoDugAux(_, I, _) => .TypeSeq requires I <Int 0 // This pattern is unreachable.
   rule #DoDugAux(TS, 0, T) => T ; TS
   rule #DoDugAux(T1 ; TS, I, T) => T1 ; #DoDugAux(TS, I -Int 1, T) requires I >Int 0
 
-  rule #TypeInstruction(C, (DUP _) #as I, T1 ; Ts) => #TI(I, T1 ; Ts -> T1 ; T1 ; Ts)
-  rule #TypeInstruction(C, (SWAP _) #as I, T1 ; T2 ; Ts) => #TI(I, T1 ; T2 ; Ts -> T2 ; T1 ; Ts)
+  rule #TypeInstruction(_, (DUP _) #as I, T1 ; Ts) => #TI(I, T1 ; Ts -> T1 ; T1 ; Ts)
+  rule #TypeInstruction(_, (SWAP _) #as I, T1 ; T2 ; Ts) => #TI(I, T1 ; T2 ; Ts -> T2 ; T1 ; Ts)
 
   syntax TypedInstruction ::= #PushAux(Instruction, MaybeData, TypeSeq) [function, functional]
 
@@ -232,14 +232,14 @@ Type Checking Rules
 
   rule #TypeInstruction(C, (PUSH _ T D) #as I, Ts) => #PushAux(I, #TypeData(C, D, T), Ts)
 
-  rule #TypeInstruction(C, (SOME _) #as I, (T1 ; Ts) #as OS) => #TI(I, OS -> option .AnnotationList T1 ; Ts)
-  rule #TypeInstruction(C, (NONE _ T) #as I, Ts) => #TI(I, Ts -> option .AnnotationList T ; Ts)
+  rule #TypeInstruction(_, (SOME _) #as I, (T1 ; Ts) #as OS) => #TI(I, OS -> option .AnnotationList T1 ; Ts)
+  rule #TypeInstruction(_, (NONE _ T) #as I, Ts) => #TI(I, Ts -> option .AnnotationList T ; Ts)
 
-  rule #TypeInstruction(C, (UNIT _) #as I, Ts) => #TI(I, Ts -> unit .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (UNIT _) #as I, Ts) => #TI(I, Ts -> unit .AnnotationList ; Ts)
 
   syntax TypedInstruction ::= #UnifyBranches(Instruction, TypedInstruction, TypedInstruction, TypeSeq) [function, functional]
 
-  rule #TypeInstruction(C, (IF_NONE A1 B1 B2) #as I, (option A2 T1 ; Ts1) #as Os) =>
+  rule #TypeInstruction(C, (IF_NONE _ B1 B2) #as I, (option _ T1 ; Ts1) #as Os) =>
        #UnifyBranches(I, #TypeInstruction(C, B1, Ts1), #TypeInstruction(C, B2, T1 ; Ts1), Os)
 
   syntax Instruction ::= #SubTypedBranches(Instruction, Block, Block) [function, functional]
@@ -267,49 +267,49 @@ Type Checking Rules
   rule #UnifyBranches(I, #TI(_, _ -> D:TypeSeq) #as B1, #TI(_, #ContractFailed) #as B2, Os) =>
        #MakeTypedBranch(#SubTypedBranches(I, { #Exec(B1) }, { #Exec(B2) }), Os -> D)
 
-  rule #UnifyBranches(I, #TI(_, #ContractFailed) #as B1, #TI(_, #ContractFailed) #as B2, Os) => #TI(I, #UnexpectedFailureType)
+  rule #UnifyBranches(I, #TI(_, #ContractFailed)       , #TI(_, #ContractFailed)       ,  _) => #TI(I, #UnexpectedFailureType)
 
   rule #UnifyBranches(I, #TI(_, TE:TypeError), #TI(_, _ -> _), _) => #TI(I, TE)
   rule #UnifyBranches(I, #TI(_, _ -> _), #TI(_, TE:TypeError), _) => #TI(I, TE)
   rule #UnifyBranches(I, #TI(_, TE1:TypeError), #TI(_, TE2:TypeError), _) => #TI(I, #MultipleTypeErrors(TE1, TE2))
   rule #UnifyBranches(I, _, _, _) => #TI(I, #InternalError) [owise] // Unreachable.
 
-  rule #TypeInstruction(C, (PAIR _) #as I, (T1 ; T2 ; Ts) #as Os) => #TI(I, Os -> pair .AnnotationList T1 T2 ; Ts)
+  rule #TypeInstruction(_, (PAIR _) #as I, (T1 ; T2 ; Ts) #as Os) => #TI(I, Os -> pair .AnnotationList T1 T2 ; Ts)
 
-  rule #TypeInstruction(C, (UNPAIR _) #as I, (pair _ T1 T2 ; Ts) #as Os) => #TI(I, Os -> T1 ; T2 ; Ts)
+  rule #TypeInstruction(_, (UNPAIR _) #as I, (pair _ T1 T2 ; Ts) #as Os) => #TI(I, Os -> T1 ; T2 ; Ts)
 
-  rule #TypeInstruction(C, (CAR _) #as I, (pair _ T1 _ ; Ts) #as Os) => #TI(I, Os -> T1 ; Ts)
-  rule #TypeInstruction(C, (CDR _) #as I, (pair _ _ T2 ; Ts) #as Os) => #TI(I, Os -> T2 ; Ts)
+  rule #TypeInstruction(_, (CAR _) #as I, (pair _ T1 _ ; Ts) #as Os) => #TI(I, Os -> T1 ; Ts)
+  rule #TypeInstruction(_, (CDR _) #as I, (pair _ _ T2 ; Ts) #as Os) => #TI(I, Os -> T2 ; Ts)
 
-  rule #TypeInstruction(C, (LEFT _ TR) #as I, (TL ; Ts) #as OS) => #TI(I, OS -> (or .AnnotationList TL TR) ; Ts)
-  rule #TypeInstruction(C, (RIGHT _ TL) #as I, (TR ; Ts) #as OS) => #TI(I, OS -> (or .AnnotationList TL TR) ; Ts)
+  rule #TypeInstruction(_, (LEFT _ TR) #as I, (TL ; Ts) #as OS) => #TI(I, OS -> (or .AnnotationList TL TR) ; Ts)
+  rule #TypeInstruction(_, (RIGHT _ TL) #as I, (TR ; Ts) #as OS) => #TI(I, OS -> (or .AnnotationList TL TR) ; Ts)
 
   rule #TypeInstruction(C, (IF_LEFT _ BL BR) #as I, ((or _ TL TR) ; Ts) #as OS) => #UnifyBranches(I, #TypeInstruction(C, BL, TL ; Ts), #TypeInstruction(C, BR, TR ; Ts), OS)
   rule #TypeInstruction(C, (IF_RIGHT _ BL BR) #as I, ((or _ TR TL) ; Ts) #as OS) => #UnifyBranches(I, #TypeInstruction(C, BL, TL ; Ts), #TypeInstruction(C, BR, TR ; Ts), OS)
 
 
-  rule #TypeInstruction(C, (NIL _ T) #as I, Ts) => #TI(I, Ts -> (list .AnnotationList T) ; Ts)
-  rule #TypeInstruction(C, (CONS _) #as I, (T ; list _ T ; Ts) #as OS) => #TI(I, OS -> list .AnnotationList T ; Ts)
+  rule #TypeInstruction(_, (NIL _ T) #as I, Ts) => #TI(I, Ts -> (list .AnnotationList T) ; Ts)
+  rule #TypeInstruction(_, (CONS _) #as I, (T ; list _ T ; Ts) #as OS) => #TI(I, OS -> list .AnnotationList T ; Ts)
 
   rule #TypeInstruction(C, (IF_CONS _ B1 B2) #as I, (list _ T ; Ts) #as OS) => #UnifyBranches(I, #TypeInstruction(C, B1, T ; list .AnnotationList T ; Ts), #TypeInstruction(C, B2, Ts), OS)
 
-  rule #TypeInstruction(C, (SIZE _) #as I, (list _ _ ; Ts) #as OS) => #TI(I, OS -> nat .AnnotationList ; Ts)
-  rule #TypeInstruction(C, (SIZE _) #as I, (set _ _ ; Ts) #as OS) => #TI(I, OS -> nat .AnnotationList ; Ts)
-  rule #TypeInstruction(C, (SIZE _) #as I, (map _ _ _ ; Ts) #as OS) => #TI(I, OS -> nat .AnnotationList ; Ts)
-  rule #TypeInstruction(C, (SIZE _) #as I, (string _ ; Ts) #as OS) => #TI(I, OS -> nat .AnnotationList ; Ts)
-  rule #TypeInstruction(C, (SIZE _) #as I, (bytes _ ; Ts) #as OS) => #TI(I, OS -> nat .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (SIZE _) #as I, (list _ _ ; Ts) #as OS) => #TI(I, OS -> nat .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (SIZE _) #as I, (set _ _ ; Ts) #as OS) => #TI(I, OS -> nat .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (SIZE _) #as I, (map _ _ _ ; Ts) #as OS) => #TI(I, OS -> nat .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (SIZE _) #as I, (string _ ; Ts) #as OS) => #TI(I, OS -> nat .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (SIZE _) #as I, (bytes _ ; Ts) #as OS) => #TI(I, OS -> nat .AnnotationList ; Ts)
 
-  rule #TypeInstruction(C, (EMPTY_SET _ T) #as I, Ts) => #TI(I, Ts -> set .AnnotationList T ; Ts)
-  rule #TypeInstruction(C, (EMPTY_MAP _ KT VT) #as I, Ts) => #TI(I, Ts -> map .AnnotationList KT VT ; Ts)
-  rule #TypeInstruction(C, (EMPTY_BIG_MAP _ KT VT) #as I, Ts) => #TI(I, Ts -> big_map .AnnotationList KT VT ; Ts)
+  rule #TypeInstruction(_, (EMPTY_SET _ T) #as I, Ts) => #TI(I, Ts -> set .AnnotationList T ; Ts)
+  rule #TypeInstruction(_, (EMPTY_MAP _ KT VT) #as I, Ts) => #TI(I, Ts -> map .AnnotationList KT VT ; Ts)
+  rule #TypeInstruction(_, (EMPTY_BIG_MAP _ KT VT) #as I, Ts) => #TI(I, Ts -> big_map .AnnotationList KT VT ; Ts)
 
- // rule #TypeInstruction(C, I, T) => #TI(I, #InvalidTypeForInstruction(I, T)) [owise]
+ // rule #TypeInstruction(_, I, T) => #TI(I, #InvalidTypeForInstruction(I, T)) [owise]
 
   syntax TypedInstruction ::= #MapAux(Instruction, TypedInstruction, TypeSeq) [function, functional]
-  rule #MapAux(MAP _ _, (#TI(_, _ -> N ; Ts) #as B), (list _ T ; Ts) #as OS) => #TI(MAP .AnnotationList { #Exec(B) }, OS -> (list .AnnotationList N) ; Ts)
+  rule #MapAux(MAP _ _, (#TI(_, _ -> N ; Ts) #as B), (list _ _ ; Ts) #as OS) => #TI(MAP .AnnotationList { #Exec(B) }, OS -> (list .AnnotationList N) ; Ts)
   rule #MapAux(MAP _ _, (#TI(_, _ -> VT ; Ts) #as B), (map _ KT _ ; Ts) #as OS) => #TI(MAP .AnnotationList  { #Exec(B) }, OS -> (map .AnnotationList KT VT) ; Ts)
 
-  rule #MapAux(I, (#TI(_, _ -> (N ; Ts1) #as DS) #as B), (_ ; Ts2) #as OS) => #TI(I, #InvalidPostIterationStack(I, OS, DS)) requires Ts1 =/=K Ts2
+  rule #MapAux(I, (#TI(_, _ -> (_ ; Ts1) #as DS)      ), (_ ; Ts2) #as OS) => #TI(I, #InvalidPostIterationStack(I, OS, DS)) requires Ts1 =/=K Ts2
   rule #MapAux(I, #TI(_, #ContractFailed),  _) => #TI(I, #UnexpectedFailureType)
   rule #MapAux(I, #TI(_, TE:TypeError),  _) => #TI(I, TE)
   rule #MapAux(I, _, _) => #TI(I, #InternalError) [owise] // Unreachable
@@ -321,7 +321,7 @@ Type Checking Rules
   syntax TypedInstruction ::= #IterAux(Instruction, TypedInstruction, TypeSeq) [function, functional]
   rule #IterAux(ITER _ _, (#TI(_, _ -> Ts) #as B), (_ ; Ts) #as OS) => #TI(ITER .AnnotationList { #Exec(B) }, OS -> Ts)
 
-  rule #IterAux(I, (#TI(_, _ -> Ts1) #as B), (_ ; Ts2) #as OS) => #TI(I, #InvalidPostIterationStack(I, OS, Ts1)) requires Ts1 =/=K Ts2
+  rule #IterAux(I, (#TI(_, _ -> Ts1)      ), (_ ; Ts2) #as OS) => #TI(I, #InvalidPostIterationStack(I, OS, Ts1)) requires Ts1 =/=K Ts2
   rule #IterAux(ITER _ _, #TI(_, #ContractFailed) #as B,  (_ ; Ts) #as OS) => #TI(ITER .AnnotationList { #Exec(B) }, OS -> Ts)
   rule #IterAux(I, #TI(_, TE:TypeError),  _) => #TI(I, TE)
   rule #IterAux(I, _, _) => #TI(I, #InternalError) [owise] // Unreachable
@@ -330,17 +330,17 @@ Type Checking Rules
   rule #TypeInstruction(C, (ITER _ B) #as I, (set _ T ; Ts) #as OS) => #IterAux(I, #TypeInstruction(C, B, T ; Ts), OS)
   rule #TypeInstruction(C, (ITER _ B) #as I, (map _ KT VT ; Ts) #as OS) => #IterAux(I, #TypeInstruction(C, B, (pair .AnnotationList KT VT) ; Ts), OS)
 
-  rule #TypeInstruction(C, (MEM _) #as I, (KT ; map _ KT VT ; Ts) #as OS) => #TI(I, OS -> bool .AnnotationList ; Ts)
-  rule #TypeInstruction(C, (MEM _) #as I, (KT ; big_map _ KT VT ; Ts) #as OS) => #TI(I, OS -> bool .AnnotationList ; Ts)
-  rule #TypeInstruction(C, (MEM _) #as I, (T ; set _ T ; Ts) #as OS) => #TI(I, OS -> bool .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (MEM _) #as I, (KT ; map _ KT _ ; Ts) #as OS) => #TI(I, OS -> bool .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (MEM _) #as I, (KT ; big_map _ KT _ ; Ts) #as OS) => #TI(I, OS -> bool .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (MEM _) #as I, (T ; set _ T ; Ts) #as OS) => #TI(I, OS -> bool .AnnotationList ; Ts)
 
-  rule #TypeInstruction(C, (GET _) #as I, (KT ; map _ KT VT ; Ts) #as OS) => #TI(I, OS -> option .AnnotationList VT ; Ts)
-  rule #TypeInstruction(C, (GET _) #as I, (KT ; big_map _ KT VT ; Ts) #as OS) => #TI(I, OS -> option .AnnotationList VT ; Ts)
+  rule #TypeInstruction(_, (GET _) #as I, (KT ; map _ KT VT ; Ts) #as OS) => #TI(I, OS -> option .AnnotationList VT ; Ts)
+  rule #TypeInstruction(_, (GET _) #as I, (KT ; big_map _ KT VT ; Ts) #as OS) => #TI(I, OS -> option .AnnotationList VT ; Ts)
 
 
-  rule #TypeInstruction(C, (UPDATE _) #as I, (KT ; option _ VT ; map _ KT VT ; Ts) #as OS) => #TI(I, OS -> map .AnnotationList KT VT ; Ts)
-  rule #TypeInstruction(C, (UPDATE _) #as I, (KT ; option _ VT ; big_map _ KT VT ; Ts) #as OS) => #TI(I, OS -> big_map .AnnotationList KT VT ; Ts)
-  rule #TypeInstruction(C, (UPDATE _) #as I, (T ; bool _ ; set _ T ; Ts) #as OS) => #TI(I, OS -> set .AnnotationList T ; Ts)
+  rule #TypeInstruction(_, (UPDATE _) #as I, (KT ; option _ VT ; map _ KT VT ; Ts) #as OS) => #TI(I, OS -> map .AnnotationList KT VT ; Ts)
+  rule #TypeInstruction(_, (UPDATE _) #as I, (KT ; option _ VT ; big_map _ KT VT ; Ts) #as OS) => #TI(I, OS -> big_map .AnnotationList KT VT ; Ts)
+  rule #TypeInstruction(_, (UPDATE _) #as I, (T ; bool _ ; set _ T ; Ts) #as OS) => #TI(I, OS -> set .AnnotationList T ; Ts)
 
   rule #TypeInstruction(C, (IF _ BL BR) #as I, (bool _ ; Ts) #as OS) => #UnifyBranches(I, #TypeInstruction(C, BL, Ts), #TypeInstruction(C, BR, Ts), OS)
 
@@ -349,7 +349,7 @@ Type Checking Rules
   rule #LoopAux( LOOP A _ , #TI(_, Ts -> (bool _) ; Ts) #as B, ((bool _) ; Ts) #as OS)
     => #TI((LOOP A { #Exec(B) }), OS -> Ts)
   rule #LoopAux(I, #TI(_, _ -> Ts1), Ts2) => #TI(I, #InvalidPostIterationStack(I, Ts1, Ts2)) requires Ts1 =/=K Ts2
-  rule #LoopAux(I, #TI(_, #ContractFailed) #as B, ((bool _) ; Ts) #as OS) => #TI((LOOP .AnnotationList { #Exec(B) }), OS -> Ts)
+  rule #LoopAux(_, #TI(_, #ContractFailed) #as B, ((bool _) ; Ts) #as OS) => #TI((LOOP .AnnotationList { #Exec(B) }), OS -> Ts)
   rule #LoopAux(I, #TI(_, TE:TypeError),  _) => #TI(I, TE)
   rule #LoopAux(I, _, _) => #TI(I, #InternalError) [owise] // Unreachable
 
@@ -359,7 +359,7 @@ Type Checking Rules
 
   rule #LoopLeftAux(LOOP_LEFT _ _, #TI(_, TL ; Ts -> (or _ TL TR) ; Ts) #as B, ((or _ TL TR) ; Ts) #as OS) => #TI((LOOP_LEFT .AnnotationList { #Exec(B) }), OS -> TR ; Ts)
   rule #LoopLeftAux(I, #TI(_, _ -> Ts1), Ts2) => #TI(I, #InvalidPostIterationStack(I, Ts1, Ts2)) requires Ts1 =/=K Ts2
-  rule #LoopLeftAux(I, #TI(_, #ContractFailed) #as B,  ((or _ TL TR) ; Ts) #as OS) => #TI((LOOP_LEFT .AnnotationList { #Exec(B) }), OS -> TR ; Ts)
+  rule #LoopLeftAux(_, #TI(_, #ContractFailed) #as B,  ((or _ _ TR) ; Ts) #as OS) => #TI((LOOP_LEFT .AnnotationList { #Exec(B) }), OS -> TR ; Ts)
   rule #LoopLeftAux(I, #TI(_, TE:TypeError),  _) => #TI(I, TE)
   rule #LoopLeftAux(I, _, _) => #TI(I, #InternalError) [owise]
 
@@ -375,11 +375,11 @@ Type Checking Rules
 
   rule #LambdaAux(I, T, Ts) => #TI(I, #LambdaError(I, T, Ts)) [owise]
 
-  rule #TypeInstruction(C, (LAMBDA _ T1 T2 B) #as I, Os) => #LambdaAux(I, #TypeInstruction(C, B, T1), Os)
+  rule #TypeInstruction(C, (LAMBDA _ T1 _ B) #as I, Os) => #LambdaAux(I, #TypeInstruction(C, B, T1), Os)
 
-  rule #TypeInstruction(C, (EXEC _) #as I, (T1 ; lambda _ T1 T2 ; Ts) #as OS) => #TI(I, OS -> T2 ; Ts)
+  rule #TypeInstruction(_, (EXEC _) #as I, (T1 ; lambda _ T1 T2 ; Ts) #as OS) => #TI(I, OS -> T2 ; Ts)
 
-  rule #TypeInstruction(C, (APPLY _) #as I, (TL ; lambda _ (pair .AnnotationList TL TR) T2 ; Ts) #as OS) => #TI(I, OS -> lambda .AnnotationList TR T2 ; Ts)
+  rule #TypeInstruction(_, (APPLY _) #as I, (TL ; lambda _ (pair .AnnotationList TL TR) T2 ; Ts) #as OS) => #TI(I, OS -> lambda .AnnotationList TR T2 ; Ts)
 
   syntax TypeInput ::= #FirstN(TypeSeq, Int) [function, functional]
 
@@ -430,116 +430,116 @@ Type Checking Rules
 
   rule #TypeInstruction(C, (DIP _ N B) #as I, OS) => #DIPAux(I, #TypeInstruction(C, B, #RemoveFirstN(OS, N)), OS)
 
-  rule #TypeInstruction(C, (FAILWITH _) #as I, _) => #TI(I, #ContractFailed)
-//  rule #TypeInstruction(C, (CAST _) #as I, Ts) => #TI(I, Ts -> Ts)
-//  rule #TypeInstruction(C, (RENAME _) #as I, Ts) => #TI(I, Ts -> Ts)
+  rule #TypeInstruction(_, (FAILWITH _) #as I, _) => #TI(I, #ContractFailed)
+  // rule #TypeInstruction(_, (CAST _) #as I, Ts) => #TI(I, Ts -> Ts)
+  // rule #TypeInstruction(_, (RENAME _) #as I, Ts) => #TI(I, Ts -> Ts)
 
-  rule #TypeInstruction(C, (CONCAT _) #as I, (string _ ; string _ ; Ts) #as OS) => #TI(I, OS -> (string .AnnotationList ; Ts))
-  rule #TypeInstruction(C, (CONCAT _) #as I, (bytes _ ; bytes _ ; Ts) #as OS) => #TI(I, OS -> (bytes .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (CONCAT _) #as I, (string _ ; string _ ; Ts) #as OS) => #TI(I, OS -> (string .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (CONCAT _) #as I, (bytes _ ; bytes _ ; Ts) #as OS) => #TI(I, OS -> (bytes .AnnotationList ; Ts))
 
-  rule #TypeInstruction(C, (CONCAT _) #as I, (list _ string _ ; Ts) #as OS) => #TI(I, OS -> (string .AnnotationList ; Ts))
-  rule #TypeInstruction(C, (CONCAT _) #as I,  (list _ bytes _ ; Ts) #as OS) => #TI(I, OS -> (bytes .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (CONCAT _) #as I, (list _ string _ ; Ts) #as OS) => #TI(I, OS -> (string .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (CONCAT _) #as I,  (list _ bytes _ ; Ts) #as OS) => #TI(I, OS -> (bytes .AnnotationList ; Ts))
 
 
 
-  rule #TypeInstruction(C, (SLICE _) #as I, (nat _ ; nat _ ; string _ ; Ts) #as OS) => #TI(I, OS -> (option .AnnotationList string .AnnotationList ; Ts))
-  rule #TypeInstruction(C, (SLICE _) #as I, (nat _ ; nat _ ; bytes _ ; Ts) #as OS) => #TI(I, OS -> (option .AnnotationList bytes .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (SLICE _) #as I, (nat _ ; nat _ ; string _ ; Ts) #as OS) => #TI(I, OS -> (option .AnnotationList string .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (SLICE _) #as I, (nat _ ; nat _ ; bytes _ ; Ts) #as OS) => #TI(I, OS -> (option .AnnotationList bytes .AnnotationList ; Ts))
 
-  rule #TypeInstruction(C, (PACK _) #as I, (T ; Ts) #as OS) => #TI(I, OS -> bytes .AnnotationList ; Ts)
-  rule #TypeInstruction(C, (UNPACK _ T) #as I, (bytes _ ; Ts) #as OS) => #TI(I, OS -> (option .AnnotationList T) ; Ts)
+  rule #TypeInstruction(_, (PACK _) #as I, (_ ; Ts) #as OS) => #TI(I, OS -> bytes .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (UNPACK _ T) #as I, (bytes _ ; Ts) #as OS) => #TI(I, OS -> (option .AnnotationList T) ; Ts)
 
-  rule #TypeInstruction(C, (ADD _) #as I, (nat _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> nat .AnnotationList ; Ts)
-  rule #TypeInstruction(C, (ADD _) #as I, (nat _ ; int _ ; Ts) #as OS) => #TI(I, OS -> int .AnnotationList ; Ts)
-  rule #TypeInstruction(C, (ADD _) #as I, (int _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> int .AnnotationList ; Ts)
-  rule #TypeInstruction(C, (ADD _) #as I, (int _ ; int _ ; Ts) #as OS) => #TI(I, OS -> int .AnnotationList ; Ts)
-  rule #TypeInstruction(C, (ADD _) #as I, (int _ ; timestamp _ ; Ts) #as OS) => #TI(I, OS -> timestamp .AnnotationList ; Ts)
-  rule #TypeInstruction(C, (ADD _) #as I, (timestamp _ ; int _ ; Ts) #as OS) => #TI(I, OS -> timestamp .AnnotationList ; Ts)
-  rule #TypeInstruction(C, (ADD _) #as I, (mutez _ ; mutez _ ; Ts) #as OS) => #TI(I, OS -> mutez .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (ADD _) #as I, (nat _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> nat .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (ADD _) #as I, (nat _ ; int _ ; Ts) #as OS) => #TI(I, OS -> int .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (ADD _) #as I, (int _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> int .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (ADD _) #as I, (int _ ; int _ ; Ts) #as OS) => #TI(I, OS -> int .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (ADD _) #as I, (int _ ; timestamp _ ; Ts) #as OS) => #TI(I, OS -> timestamp .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (ADD _) #as I, (timestamp _ ; int _ ; Ts) #as OS) => #TI(I, OS -> timestamp .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (ADD _) #as I, (mutez _ ; mutez _ ; Ts) #as OS) => #TI(I, OS -> mutez .AnnotationList ; Ts)
 
-  rule #TypeInstruction(C, (SUB _) #as I, (nat _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> int .AnnotationList ; Ts)
-  rule #TypeInstruction(C, (SUB _) #as I, (nat _ ; int _ ; Ts) #as OS) => #TI(I, OS -> int .AnnotationList ; Ts)
-  rule #TypeInstruction(C, (SUB _) #as I, (int _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> int .AnnotationList ; Ts)
-  rule #TypeInstruction(C, (SUB _) #as I, (int _ ; int _ ; Ts) #as OS) => #TI(I, OS -> int .AnnotationList ; Ts)
-  rule #TypeInstruction(C, (SUB _) #as I, (timestamp _ ; int _ ; Ts) #as OS) => #TI(I, OS -> timestamp .AnnotationList ; Ts)
-  rule #TypeInstruction(C, (SUB _) #as I, (timestamp _ ; timestamp _ ; Ts) #as OS) => #TI(I, OS -> int .AnnotationList ; Ts)
-  rule #TypeInstruction(C, (SUB _) #as I, (mutez _ ; mutez _ ; Ts) #as OS) => #TI(I, OS -> mutez .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (SUB _) #as I, (nat _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> int .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (SUB _) #as I, (nat _ ; int _ ; Ts) #as OS) => #TI(I, OS -> int .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (SUB _) #as I, (int _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> int .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (SUB _) #as I, (int _ ; int _ ; Ts) #as OS) => #TI(I, OS -> int .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (SUB _) #as I, (timestamp _ ; int _ ; Ts) #as OS) => #TI(I, OS -> timestamp .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (SUB _) #as I, (timestamp _ ; timestamp _ ; Ts) #as OS) => #TI(I, OS -> int .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (SUB _) #as I, (mutez _ ; mutez _ ; Ts) #as OS) => #TI(I, OS -> mutez .AnnotationList ; Ts)
 
-  rule #TypeInstruction(C, (MUL _) #as I, (nat _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> nat .AnnotationList ; Ts)
-  rule #TypeInstruction(C, (MUL _) #as I, (nat _ ; int _ ; Ts) #as OS) => #TI(I, OS -> int .AnnotationList ; Ts)
-  rule #TypeInstruction(C, (MUL _) #as I, (int _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> int .AnnotationList ; Ts)
-  rule #TypeInstruction(C, (MUL _) #as I, (int _ ; int _ ; Ts) #as OS) => #TI(I, OS -> int .AnnotationList ; Ts)
-  rule #TypeInstruction(C, (MUL _) #as I, (mutez _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> mutez .AnnotationList ; Ts)
-  rule #TypeInstruction(C, (MUL _) #as I, (nat _ ; mutez _ ; Ts) #as OS) => #TI(I, OS -> mutez .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (MUL _) #as I, (nat _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> nat .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (MUL _) #as I, (nat _ ; int _ ; Ts) #as OS) => #TI(I, OS -> int .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (MUL _) #as I, (int _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> int .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (MUL _) #as I, (int _ ; int _ ; Ts) #as OS) => #TI(I, OS -> int .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (MUL _) #as I, (mutez _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> mutez .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (MUL _) #as I, (nat _ ; mutez _ ; Ts) #as OS) => #TI(I, OS -> mutez .AnnotationList ; Ts)
 
-  rule #TypeInstruction(C, (EDIV _) #as I, (nat _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> option .AnnotationList pair .AnnotationList nat .AnnotationList nat .AnnotationList ; Ts)
-  rule #TypeInstruction(C, (EDIV _) #as I, (int _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> option .AnnotationList pair .AnnotationList int .AnnotationList nat .AnnotationList ; Ts)
-  rule #TypeInstruction(C, (EDIV _) #as I, (nat _ ; int _ ; Ts) #as OS) => #TI(I, OS -> option .AnnotationList pair .AnnotationList int .AnnotationList nat .AnnotationList ; Ts)
-  rule #TypeInstruction(C, (EDIV _) #as I, (int _ ; int _ ; Ts) #as OS) => #TI(I, OS -> option .AnnotationList pair .AnnotationList int .AnnotationList nat .AnnotationList ; Ts)
-  rule #TypeInstruction(C, (EDIV _) #as I, (mutez _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> option .AnnotationList pair .AnnotationList mutez .AnnotationList mutez .AnnotationList ; Ts)
-  rule #TypeInstruction(C, (EDIV _) #as I, (mutez _ ; mutez _ ; Ts) #as OS) => #TI(I, OS -> option .AnnotationList pair .AnnotationList nat .AnnotationList mutez .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (EDIV _) #as I, (nat _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> option .AnnotationList pair .AnnotationList nat .AnnotationList nat .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (EDIV _) #as I, (int _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> option .AnnotationList pair .AnnotationList int .AnnotationList nat .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (EDIV _) #as I, (nat _ ; int _ ; Ts) #as OS) => #TI(I, OS -> option .AnnotationList pair .AnnotationList int .AnnotationList nat .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (EDIV _) #as I, (int _ ; int _ ; Ts) #as OS) => #TI(I, OS -> option .AnnotationList pair .AnnotationList int .AnnotationList nat .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (EDIV _) #as I, (mutez _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> option .AnnotationList pair .AnnotationList mutez .AnnotationList mutez .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (EDIV _) #as I, (mutez _ ; mutez _ ; Ts) #as OS) => #TI(I, OS -> option .AnnotationList pair .AnnotationList nat .AnnotationList mutez .AnnotationList ; Ts)
 
-  rule #TypeInstruction(C, (ABS _) #as I, (int _ ; Ts) #as OS) => #TI(I, OS -> (nat .AnnotationList ; Ts))
-  rule #TypeInstruction(C, (ISNAT _) #as I, (int _ ; Ts) #as OS) => #TI(I, OS -> (option .AnnotationList nat .AnnotationList ; Ts))
-  rule #TypeInstruction(C, (INT _) #as I, (nat _ ; Ts) #as OS) => #TI(I, OS -> (int .AnnotationList ; Ts))
-  rule #TypeInstruction(C, (NEG _) #as I, (int _ ; Ts) #as OS) => #TI(I, OS -> (int .AnnotationList ; Ts))
-  rule #TypeInstruction(C, (NEG _) #as I, (nat _ ; Ts) #as OS) => #TI(I, OS -> (int .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (ABS _) #as I, (int _ ; Ts) #as OS) => #TI(I, OS -> (nat .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (ISNAT _) #as I, (int _ ; Ts) #as OS) => #TI(I, OS -> (option .AnnotationList nat .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (INT _) #as I, (nat _ ; Ts) #as OS) => #TI(I, OS -> (int .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (NEG _) #as I, (int _ ; Ts) #as OS) => #TI(I, OS -> (int .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (NEG _) #as I, (nat _ ; Ts) #as OS) => #TI(I, OS -> (int .AnnotationList ; Ts))
 
-  rule #TypeInstruction(C, (LSL _) #as I, (nat _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> (nat .AnnotationList ; Ts))
-  rule #TypeInstruction(C, (LSR _) #as I, (nat _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> (nat .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (LSL _) #as I, (nat _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> (nat .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (LSR _) #as I, (nat _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> (nat .AnnotationList ; Ts))
 
-  rule #TypeInstruction(C, (OR _) #as I, (nat _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> (nat .AnnotationList ; Ts))
-  rule #TypeInstruction(C, (OR _) #as I, (bool _ ; bool _ ; Ts) #as OS) => #TI(I, OS -> (bool .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (OR _) #as I, (nat _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> (nat .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (OR _) #as I, (bool _ ; bool _ ; Ts) #as OS) => #TI(I, OS -> (bool .AnnotationList ; Ts))
 
-  rule #TypeInstruction(C, (AND _) #as I, (nat _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> (nat .AnnotationList ; Ts))
-  rule #TypeInstruction(C, (AND _) #as I, (int _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> (nat .AnnotationList ; Ts))
-  rule #TypeInstruction(C, (AND _) #as I, (bool _ ; bool _ ; Ts) #as OS) => #TI(I, OS -> (bool .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (AND _) #as I, (nat _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> (nat .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (AND _) #as I, (int _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> (nat .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (AND _) #as I, (bool _ ; bool _ ; Ts) #as OS) => #TI(I, OS -> (bool .AnnotationList ; Ts))
 
-  rule #TypeInstruction(C, (XOR _) #as I, (nat _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> (nat .AnnotationList ; Ts))
-  rule #TypeInstruction(C, (XOR _) #as I, (bool _ ; bool _ ; Ts) #as OS) => #TI(I, OS -> (bool .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (XOR _) #as I, (nat _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> (nat .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (XOR _) #as I, (bool _ ; bool _ ; Ts) #as OS) => #TI(I, OS -> (bool .AnnotationList ; Ts))
 
-  rule #TypeInstruction(C, (NOT _) #as I, (nat _ ; Ts) #as OS) => #TI(I, OS -> (int .AnnotationList ; Ts))
-  rule #TypeInstruction(C, (NOT _) #as I, (int _ ; Ts) #as OS) => #TI(I, OS -> (int .AnnotationList ; Ts))
-  rule #TypeInstruction(C, (NOT _) #as I, (bool _ ; Ts) #as OS) => #TI(I, OS -> (bool .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (NOT _) #as I, (nat _ ; Ts) #as OS) => #TI(I, OS -> (int .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (NOT _) #as I, (int _ ; Ts) #as OS) => #TI(I, OS -> (int .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (NOT _) #as I, (bool _ ; Ts) #as OS) => #TI(I, OS -> (bool .AnnotationList ; Ts))
 
-  rule #TypeInstruction(C, (COMPARE _) #as I, (nat _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> (int .AnnotationList ; Ts))
-  rule #TypeInstruction(C, (COMPARE _) #as I, (bool _ ; bool _ ; Ts) #as OS) => #TI(I, OS -> (int .AnnotationList ; Ts))
-  rule #TypeInstruction(C, (COMPARE _) #as I, (int _ ; int _ ; Ts) #as OS) => #TI(I, OS -> (int .AnnotationList ; Ts))
-  rule #TypeInstruction(C, (COMPARE _) #as I, (string _ ; string _ ; Ts) #as OS) => #TI(I, OS -> (int .AnnotationList ; Ts))
-  rule #TypeInstruction(C, (COMPARE _) #as I, (pair _ A B ; pair _ A B ; Ts) #as OS) => #TI(I, OS -> (int .AnnotationList ; Ts))
-  rule #TypeInstruction(C, (COMPARE _) #as I, (timestamp _ ; timestamp _ ; Ts) #as OS) => #TI(I, OS -> (int .AnnotationList ; Ts))
-  rule #TypeInstruction(C, (COMPARE _) #as I, (mutez _ ; mutez _ ; Ts) #as OS) => #TI(I, OS -> (int .AnnotationList ; Ts))
-  rule #TypeInstruction(C, (COMPARE _) #as I, (bytes _ ; bytes _ ; Ts) #as OS) => #TI(I, OS -> (int .AnnotationList ; Ts))
-  rule #TypeInstruction(C, (COMPARE _) #as I, (key_hash _ ; key_hash _ ; Ts) #as OS) => #TI(I, OS -> (int .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (COMPARE _) #as I, (nat _ ; nat _ ; Ts) #as OS) => #TI(I, OS -> (int .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (COMPARE _) #as I, (bool _ ; bool _ ; Ts) #as OS) => #TI(I, OS -> (int .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (COMPARE _) #as I, (int _ ; int _ ; Ts) #as OS) => #TI(I, OS -> (int .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (COMPARE _) #as I, (string _ ; string _ ; Ts) #as OS) => #TI(I, OS -> (int .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (COMPARE _) #as I, (pair _ A B ; pair _ A B ; Ts) #as OS) => #TI(I, OS -> (int .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (COMPARE _) #as I, (timestamp _ ; timestamp _ ; Ts) #as OS) => #TI(I, OS -> (int .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (COMPARE _) #as I, (mutez _ ; mutez _ ; Ts) #as OS) => #TI(I, OS -> (int .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (COMPARE _) #as I, (bytes _ ; bytes _ ; Ts) #as OS) => #TI(I, OS -> (int .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (COMPARE _) #as I, (key_hash _ ; key_hash _ ; Ts) #as OS) => #TI(I, OS -> (int .AnnotationList ; Ts))
 
-  rule #TypeInstruction(C, (EQ _) #as I, (int _ ; Ts) #as OS) => #TI(I, OS -> (bool .AnnotationList ; Ts))
-  rule #TypeInstruction(C, (NEQ _) #as I, (int _ ; Ts) #as OS) => #TI(I, OS -> (bool .AnnotationList ; Ts))
-  rule #TypeInstruction(C, (LT _) #as I, (int _ ; Ts) #as OS) => #TI(I, OS -> (bool .AnnotationList ; Ts))
-  rule #TypeInstruction(C, (GT _) #as I, (int _ ; Ts) #as OS) => #TI(I, OS -> (bool .AnnotationList ; Ts))
-  rule #TypeInstruction(C, (LE _) #as I, (int _ ; Ts) #as OS) => #TI(I, OS -> (bool .AnnotationList ; Ts))
-  rule #TypeInstruction(C, (GE _) #as I, (int _ ; Ts) #as OS) => #TI(I, OS -> (bool .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (EQ _) #as I, (int _ ; Ts) #as OS) => #TI(I, OS -> (bool .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (NEQ _) #as I, (int _ ; Ts) #as OS) => #TI(I, OS -> (bool .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (LT _) #as I, (int _ ; Ts) #as OS) => #TI(I, OS -> (bool .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (GT _) #as I, (int _ ; Ts) #as OS) => #TI(I, OS -> (bool .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (LE _) #as I, (int _ ; Ts) #as OS) => #TI(I, OS -> (bool .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (GE _) #as I, (int _ ; Ts) #as OS) => #TI(I, OS -> (bool .AnnotationList ; Ts))
 
   rule #TypeInstruction(C, (SELF _) #as I, OS) => #TI(I, OS -> (contract .AnnotationList C) ; OS)
 
-  rule #TypeInstruction(C, (CONTRACT _ T) #as I, ((address _) ; Ts) #as OS) => #TI(I, OS -> (option .AnnotationList contract .AnnotationList T) ; Ts)
+  rule #TypeInstruction(_, (CONTRACT _ T) #as I, ((address _) ; Ts) #as OS) => #TI(I, OS -> (option .AnnotationList contract .AnnotationList T) ; Ts)
 
-  rule #TypeInstruction(C, (TRANSFER_TOKENS _) #as I, (T ; mutez _ ; contract _ T ; Ts) #as OS) => #TI(I, OS -> (operation .AnnotationList) ; Ts)
-  rule #TypeInstruction(C, (SET_DELEGATE _) #as I, (option _ key_hash _ ; Ts) #as OS) => #TI(I, OS -> (operation .AnnotationList) ; Ts)
+  rule #TypeInstruction(_, (TRANSFER_TOKENS _) #as I, (T ; mutez _ ; contract _ T ; Ts) #as OS) => #TI(I, OS -> (operation .AnnotationList) ; Ts)
+  rule #TypeInstruction(_, (SET_DELEGATE _) #as I, (option _ key_hash _ ; Ts) #as OS) => #TI(I, OS -> (operation .AnnotationList) ; Ts)
 
-  rule #TypeInstruction(C, (NOW _) #as I, OS) => #TI(I, OS -> (timestamp .AnnotationList) ; OS)
-  rule #TypeInstruction(C, (CHAIN_ID _) #as I, OS) => #TI(I, OS -> (chain_id .AnnotationList) ; OS)
-  rule #TypeInstruction(C, (AMOUNT _) #as I, OS) => #TI(I, OS -> (mutez .AnnotationList) ; OS)
-  rule #TypeInstruction(C, (BALANCE _) #as I, OS) => #TI(I, OS -> (mutez .AnnotationList) ; OS)
-  rule #TypeInstruction(C, (CHECK_SIGNATURE _) #as I, (key _ ; signature _ ; bytes _ ; Ts) #as OS) => #TI(I, OS -> bool .AnnotationList ; Ts)
+  rule #TypeInstruction(_, (NOW _) #as I, OS) => #TI(I, OS -> (timestamp .AnnotationList) ; OS)
+  rule #TypeInstruction(_, (CHAIN_ID _) #as I, OS) => #TI(I, OS -> (chain_id .AnnotationList) ; OS)
+  rule #TypeInstruction(_, (AMOUNT _) #as I, OS) => #TI(I, OS -> (mutez .AnnotationList) ; OS)
+  rule #TypeInstruction(_, (BALANCE _) #as I, OS) => #TI(I, OS -> (mutez .AnnotationList) ; OS)
+  rule #TypeInstruction(_, (CHECK_SIGNATURE _) #as I, (key _ ; signature _ ; bytes _ ; Ts) #as OS) => #TI(I, OS -> bool .AnnotationList ; Ts)
 
-  rule #TypeInstruction(C, (BLAKE2B _) #as I, (bytes _ ; Ts) #as OS) => #TI(I, OS -> OS)
-  rule #TypeInstruction(C, (SHA256 _) #as I, (bytes _ ; Ts) #as OS) => #TI(I, OS -> OS)
-  rule #TypeInstruction(C, (SHA512 _) #as I, (bytes _ ; Ts) #as OS) => #TI(I, OS -> OS)
+  rule #TypeInstruction(_, (BLAKE2B _) #as I, (bytes _ ; _) #as OS) => #TI(I, OS -> OS)
+  rule #TypeInstruction(_, (SHA256 _) #as I, (bytes _ ; _) #as OS) => #TI(I, OS -> OS)
+  rule #TypeInstruction(_, (SHA512 _) #as I, (bytes _ ; _) #as OS) => #TI(I, OS -> OS)
 
-  rule #TypeInstruction(C, (HASH_KEY _) #as I, (key _ ; Ts) #as OS) => #TI(I, OS -> (key_hash .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (HASH_KEY _) #as I, (key _ ; Ts) #as OS) => #TI(I, OS -> (key_hash .AnnotationList ; Ts))
 
-  rule #TypeInstruction(C, (SOURCE _) #as I, OS) => #TI(I, OS -> (address .AnnotationList) ; OS)
-  rule #TypeInstruction(C, (SENDER _) #as I, OS) => #TI(I, OS -> (address .AnnotationList) ; OS)
-  rule #TypeInstruction(C, (ADDRESS _) #as I, (contract _ _ ; Ts) #as OS) => #TI(I, OS -> (address .AnnotationList) ; Ts)
+  rule #TypeInstruction(_, (SOURCE _) #as I, OS) => #TI(I, OS -> (address .AnnotationList) ; OS)
+  rule #TypeInstruction(_, (SENDER _) #as I, OS) => #TI(I, OS -> (address .AnnotationList) ; OS)
+  rule #TypeInstruction(_, (ADDRESS _) #as I, (contract _ _ ; Ts) #as OS) => #TI(I, OS -> (address .AnnotationList) ; Ts)
 
   rule #TypeInstruction(C, (TRACE(S)) #as I, OS) => #TI(I, OS -> OS)
   rule #TypeInstruction(C, STOP       #as I, OS) => #TI(I, OS -> OS)
@@ -554,8 +554,8 @@ Type Checking Rules
        #TI(CREATE_CONTRACT .AnnotationList { code B ; storage St ; parameter Pt ; }, OS -> operation .AnnotationList ; address .AnnotationList ; Ts)
   rule #CreateContractAux(I, TI, TS) => #TI(I, #CreateContractError(TI, TS)) [owise]
 
-  rule #TypeInstruction(C, (CREATE_CONTRACT _ { code B ; storage St ; parameter Pt ; }) #as I, OS) => #CreateContractAux(I, #TypeInstruction(Pt, B, pair .AnnotationList Pt St), OS)
+  rule #TypeInstruction(_, (CREATE_CONTRACT _ { code B ; storage St ; parameter Pt ; }) #as I, OS) => #CreateContractAux(I, #TypeInstruction(Pt, B, pair .AnnotationList Pt St), OS)
 
-  rule #TypeInstruction(C, (IMPLICIT_ACCOUNT _) #as I, (key_hash _ ; Ts) #as OS) => #TI(I, OS -> (contract .AnnotationList unit .AnnotationList ; Ts))
+  rule #TypeInstruction(_, (IMPLICIT_ACCOUNT _) #as I, (key_hash _ ; Ts) #as OS) => #TI(I, OS -> (contract .AnnotationList unit .AnnotationList ; Ts))
 endmodule
 ```

--- a/michelson/types.md
+++ b/michelson/types.md
@@ -245,7 +245,6 @@ Type Checking Rules
 
   rule #SubTypedBranches(IF_NONE _ _ _, B1, B2)  => IF_NONE  .AnnotationList B1 B2
   rule #SubTypedBranches(IF_LEFT _ _ _, B1, B2)  => IF_LEFT  .AnnotationList B1 B2
-  rule #SubTypedBranches(IF_RIGHT _ _ _, B1, B2) => IF_RIGHT .AnnotationList B1 B2
   rule #SubTypedBranches(IF_CONS _ _ _, B1, B2)  => IF_CONS  .AnnotationList B1 B2
   rule #SubTypedBranches(IF      _ _ _, B1, B2)  => IF       .AnnotationList B1 B2
   rule #SubTypedBranches(I, _, _) => #InvalidBranchInstruction(I) [owise]
@@ -284,7 +283,6 @@ Type Checking Rules
   rule #TypeInstruction(_, (RIGHT _ TL) #as I, (TR ; Ts) #as OS) => #TI(I, OS -> (or .AnnotationList TL TR) ; Ts)
 
   rule #TypeInstruction(C, (IF_LEFT _ BL BR) #as I, ((or _ TL TR) ; Ts) #as OS) => #UnifyBranches(I, #TypeInstruction(C, BL, TL ; Ts), #TypeInstruction(C, BR, TR ; Ts), OS)
-  rule #TypeInstruction(C, (IF_RIGHT _ BL BR) #as I, ((or _ TR TL) ; Ts) #as OS) => #UnifyBranches(I, #TypeInstruction(C, BL, TL ; Ts), #TypeInstruction(C, BR, TR ; Ts), OS)
 
 
   rule #TypeInstruction(_, (NIL _ T) #as I, Ts) => #TI(I, Ts -> (list .AnnotationList T) ; Ts)

--- a/tests/failing.unit
+++ b/tests/failing.unit
@@ -18,3 +18,5 @@ tests/unit/slice_bytes_02.tzt
 tests/unit/slice_bytes_03.tzt
 tests/unit/slice_bytes_04.tzt
 tests/unit/sub_timestamp-int_04.tzt
+tests/unit/ifright_orintstring_00.tzt
+tests/unit/ifright_orstringint_00.tzt

--- a/tests/failing.unit
+++ b/tests/failing.unit
@@ -16,3 +16,10 @@ tests/unit/slice_bytes_02.tzt
 tests/unit/slice_bytes_03.tzt
 tests/unit/slice_bytes_04.tzt
 tests/unit/sub_timestamp-int_04.tzt
+
+tests/macros/cdda.tzt
+tests/macros/cdddr.tzt
+tests/macros/cmpeq_00.tzt
+tests/macros/ifcmpeq.tzt
+tests/macros/pappaiir.tzt
+tests/macros/unpappaiir.tzt

--- a/tests/failing.unit
+++ b/tests/failing.unit
@@ -9,8 +9,6 @@ tests/unit/concat_listbytes_00.tzt
 tests/unit/concat_listbytes_01.tzt
 tests/unit/concat_listbytes_02.tzt
 tests/unit/createcontract_00.tzt
-tests/unit/ifsome_optionint_00.tzt
-tests/unit/ifsome_optionint_01.tzt
 tests/unit/size_bytes_00.tzt
 tests/unit/slice_bytes_00.tzt
 tests/unit/slice_bytes_01.tzt
@@ -18,5 +16,3 @@ tests/unit/slice_bytes_02.tzt
 tests/unit/slice_bytes_03.tzt
 tests/unit/slice_bytes_04.tzt
 tests/unit/sub_timestamp-int_04.tzt
-tests/unit/ifright_orintstring_00.tzt
-tests/unit/ifright_orstringint_00.tzt

--- a/unit-test/unit-test.md
+++ b/unit-test/unit-test.md
@@ -47,7 +47,6 @@ module UNIT-TEST
   syntax KItem ::= SymbolicElement
 
   syntax SymbolicElement ::= #SymbolicElement(SymbolicData, Type)
-  syntax SymbolicElement ::= "#DummyElement"
 
   syntax Set ::= #FindSymbolsBL(BlockList) [function, functional]
   rule #FindSymbolsBL(.BlockList) => .Set
@@ -87,7 +86,7 @@ module UNIT-TEST
 
   rule #FindSymbolsIn({ }, map _ _ _) => .Set
   rule #FindSymbolsIn({ Elt K V }, map _ KT VT) => #FindSymbolsIn(K, KT) |Set #FindSymbolsIn(V, VT)
-  rule #FindSymbolsIn({ M:MapEntry ; ML:MapEntryList }, (map _ K V) #as MT) =>
+  rule #FindSymbolsIn({ M:MapEntry ; ML:MapEntryList }, (map _ _ _) #as MT) =>
        #FindSymbolsIn({ M }, MT) |Set #FindSymbolsIn({ ML }, MT)
 
   rule #FindSymbolsIn(M:MapLiteral, big_map A KT VT) => #FindSymbolsIn(M, map A KT VT)
@@ -187,7 +186,7 @@ productions) into a KSequence (the same format as the execution stack).
 
 ```k
   syntax K ::= #LiteralStackToSemantics(LiteralStack, Map, Map) [function]
-  rule #LiteralStackToSemantics({ .StackElementList }, KnownAddrs, BigMaps) => .
+  rule #LiteralStackToSemantics({ .StackElementList }, _KnownAddrs, _BigMaps) => .
   rule #LiteralStackToSemantics({ Stack_elt T D ; Gs:StackElementList }, KnownAddrs, BigMaps)
     => #MichelineToNative(D, T, KnownAddrs, BigMaps)
     ~> #LiteralStackToSemantics({ Gs }, KnownAddrs, BigMaps)
@@ -247,7 +246,7 @@ know what types are on the stack.
   rule #LiteralStackToTypes( { Stack_elt T D ; Gs:StackElementList }, PT)
     => T ; #LiteralStackToTypes({ Gs }, PT)
     requires #Typed(D, T) :=K #TypeData(PT, D, T)
-  rule #LiteralStackToTypes({ Stack_elt T S:SymbolicData ; Gs:StackElementList }, PT)
+  rule #LiteralStackToTypes({ Stack_elt T _:SymbolicData ; Gs:StackElementList }, PT)
     => T ; #LiteralStackToTypes({ Gs }, PT)
 ```
 
@@ -289,7 +288,7 @@ TODO: Consider best way to introduce type-checks to pre/post conditions
   syntax KItem ::= #TypeCheck(Block, Type, LiteralStack, OutputStack)
   syntax KItem ::= #TypeCheckAux(LiteralStack, LiteralStack, TypeSeq, TypedInstruction)
 
-  rule <k> #TypeCheck(B,P,IS,OS:LiteralStack)
+  rule <k> #TypeCheck(B, P, IS, OS:LiteralStack)
         => #TypeCheckAux(
              IS,
              OS,
@@ -300,10 +299,10 @@ TODO: Consider best way to introduce type-checks to pre/post conditions
        </k>
 
   // TODO: Implement a "partial" type check case
-  rule <k> #TypeCheck(B,P,IS,OS:FailedStack) => . ... </k>
+  rule <k> #TypeCheck(B, _P, _IS, _OS:FailedStack) => . ... </k>
        <script> B </script>
 
-  rule <k> #TypeCheckAux(IS, OS, OSTypes, #TI(B, ISTypes -> OSTypes))
+  rule <k> #TypeCheckAux(_IS, _OS, OSTypes, #TI(B, ISTypes -> OSTypes))
         => .
            ...
        </k>


### PR DESCRIPTION
Commit 'michelson/common.md: address unused variable warnings' appears to be last good commit.

Building with the last commit causes compilation errors (bison) when building the core semantics.

It seems like some unused symbol is accidentally getting imported into the main semantics but I cannot figure out which one.