### PR TITLE
Add `in_keys`, `lookup`, and `in` simplification rules

### DIFF
--- a/michelson.md
+++ b/michelson.md
@@ -1311,6 +1311,10 @@ strings, allowing for code reuse.
        <stack> S:Set => size(S) ... </stack>
 ```
 
+```symbolic
+  rule V1 in S:Set SetItem(V2) => V1 ==K V2 orBool V1 in S [simplification]
+```
+
 Note that, according to the Michelson documentation, set iteration order is
 actually defined (the set is iterated over in ascending order).
 For simplicity we implement this by repeatedly selecting the minimal element.

--- a/michelson.md
+++ b/michelson.md
@@ -1368,7 +1368,11 @@ For simplicity we implement this by repeatedly selecting the minimal element.
        // TODO: figure out how to support this in pre/post-conditions which are not typechecked
        // <stacktypes> KT:Type ; map _:AnnotationList KT VT:Type </stacktypes>
 
-  rule K1 in_keys(M:Map[ K2 <- _ ]) => K1 ==K K2 orBool K1 in_keys(M) [simplification]
+  rule K1 in_keys(M:Map[ K2 <- _    ]) =>          K1 ==K K2  orBool  K1 in_keys(M) [simplification]
+  rule K1 in_keys(M:Map[ K2 <- undef]) => (notBool K1 ==K K2) andBool K1 in_keys(M) [simplification]
+
+  rule (M:Map [ K1 <- V ]) [ K1 ] => V                                              [simplification]
+  rule (M:Map [ K2 <- V ]) [ K1 ] => (M:Map [ K1 ]) requires notBool K1 ==K K2      [simplification]
 ```
 
 ```k

--- a/tests/failing.symbolic
+++ b/tests/failing.symbolic
@@ -2,5 +2,4 @@ tests/symbolic/small-loop.tzt
 tests/symbolic/illtyped.stuck.tzt
 tests/symbolic/pair-deconstruct.tzt
 tests/symbolic/vote-simple.tzt
-tests/symbolic/map_update_01.tzt
 tests/symbolic/set_update_01.tzt


### PR DESCRIPTION
So, I'm marking this PR as draft, given these updates are right around the corner:

https://github.com/kframework/kore/pull/2084
https://github.com/kframework/kore/pull/2073

Once these updates are merged, we should check if `map_update_01.tzt` works without the `in_keys` lemmas. If it does, we can update the PR to remove those lemmas.