### PR TITLE
Reimplement Michelson `list`s using `InternalList`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ ALL_FILES          := $(patsubst %, %.md, $(SOURCE_FILES) $(EXTRA_SOURCE_FILES))
 tangle_haskell := k | symbolic
 tangle_llvm    := k | concrete
 
-HOOK_NAMESPACES := TIME MICHELSON
+HOOK_NAMESPACES := TIME
 
 # NOTE: -W useless-rule check is quite expensive (increasing compilation times by several times), use -Wno useless-rule unless this check is needed!!!
 KOMPILE_OPTS += --hook-namespaces "$(HOOK_NAMESPACES)" --gen-bison-parser --emit-json -w all -Wno unused-symbol -Wno useless-rule

--- a/michelson.md
+++ b/michelson.md
@@ -1164,7 +1164,8 @@ We define `COMPARE` in terms of a `#DoCompare` function.
 The `#DoCompare` function requires additional lemmas for symbolic execution.
 
 ```symbolic
-  rule #DoCompare(V1, V2) ==Int 0 => V1 ==K V2 [simplification]
+  rule #DoCompare(V1, V2)  ==Int 0 => V1  ==K V2 [simplification]
+  rule #DoCompare(V1, V2) =/=Int 0 => V1 =/=K V2 [simplification]
 
   rule #DoCompare(I1:Bool, I2:Bool) <Int 0  => (I1 ==Bool false) andBool (I2 ==Bool true)                       [simplification]
   rule #DoCompare(I1:Bool, I2:Bool) <=Int 0 => ((I1 ==Bool false) andBool (I2 ==Bool true)) orBool I1 ==Bool I2 [simplification]


### PR DESCRIPTION
As I understand, the builtin list can cause problems with theorem proving, so we use a custom list implementation.