### PR TITLE
michelson: add file inclusion functionality

### DIFF
--- a/kmich
+++ b/kmich
@@ -175,6 +175,8 @@ llvm_krun_args=()
     || llvm_krun_args+=(--debug)
 ! echo "$backend_dir" | grep -e contract-expander -e extractor -e input-creator -e output-compare &> /dev/null \
     || llvm_krun_args+=(-c IO '\dv{SortString{}}("on")' String kore)
+[[ ! "$backend" == "llvm" ]] \
+    || llvm_krun_args+=(-c PATH "\"$(dirname $run_file)\"" String pretty)
 
 export PATH="$kompiled_dir:$PATH"
 

--- a/kmich
+++ b/kmich
@@ -21,7 +21,7 @@ if [[ ! -f "${k_release_dir}/bin/kompile" ]]; then
     fi
 fi
 
-export PATH="$scriptpath/lib:$k_release_dir/bin:$PATH"
+PATH="$scriptpath/lib:$k_release_dir/bin:$PATH"
 export LD_LIBRARY_PATH="$k_release_dir/lib/native/linux64:$lib_dir:${LD_LIBRARY_PATH:-}"
 export PYTHONPATH="$k_release_dir/lib/kframework:${PYTHONPATH:-}"
 
@@ -175,6 +175,8 @@ llvm_krun_args=()
     || llvm_krun_args+=(--debug)
 ! echo "$backend_dir" | grep -e contract-expander -e extractor -e input-creator -e output-compare &> /dev/null \
     || llvm_krun_args+=(-c IO '\dv{SortString{}}("on")' String kore)
+
+export PATH="$kompiled_dir:$PATH"
 
 case "$run_command-$backend" in
 

--- a/michelson.md
+++ b/michelson.md
@@ -105,7 +105,16 @@ These cells store the Michelson interpreter runtime state.
       <cutpoints> .Set </cutpoints>
       <savedContext> NoContext </savedContext>
       <currentContext> _default </currentContext>
+```
+
+#### Concrete Interpreter Runtime State
+
+The following runtime state cells are not supported by the symbolic
+interpreter.
+
+```concrete
       <importMap> .Map </importMap>
+      <fileLocation parser="PATH,STRING-SYNTAX"> $PATH:String </fileLocation>
 ```
 
 ```k
@@ -263,7 +272,13 @@ Below are the rules for loading specific groups.
        <post> .BlockList => Bs </post>
 
   rule <k> test Name { TestBlock } => #SwapContext(Name, TestBlock) ... </k>
+```
 
+##### Concrete Extended Unit Test Groups
+
+The following unit test groups are not supported by the symbolic interpreter.
+
+```concrete
   rule <k> import Path as Name => .K ... </k>
        <importMap> Imports => Imports[Name <- loadFile(Path)] </importMap>
     requires notBool Name in_keys(Imports)

--- a/michelson.md
+++ b/michelson.md
@@ -280,19 +280,29 @@ The following unit test groups are not supported by the symbolic interpreter.
 
 ```concrete
   rule <k> import Path as Name => .K ... </k>
-       <importMap> Imports => Imports[Name <- loadFile(Path)] </importMap>
-    requires notBool Name in_keys(Imports)
+       <importMap> Imports => Imports[Name <- loadFile(Dir,Path)] </importMap>
+       <fileLocation> Dir </fileLocation>
+    requires validPath(Path)
+     andBool notBool Name in_keys(Imports)
 
   rule <k> include Name => Imports[Name] ... </k>
        <importMap> Imports </importMap>
     requires Name in_keys(Imports)
 
-  rule <k> include-file Path => loadFile(Path) ... </k>
+  rule <k> include-file Path => loadFile(Dir,Path) ... </k>
+       <fileLocation> Dir </fileLocation>
+    requires validPath(Path)
 
-  syntax Pgm ::= loadFile(String) [function]
-               | parseFile(KItem) [function]
-  // ---------------------------------------
-  rule loadFile(Path) => parseFile(#system("parser_PGM \"" +String Path +String "\""))
+  syntax Bool ::= validPath(String) [function]
+  // -----------------------------------------
+  rule validPath(Path) =>         lengthString(Path) >=Int 0
+                          andBool substrString(Path,0,1) =/=String "/"
+
+  syntax Pgm ::= loadFile(String, String) [function]
+               | parseFile(KItem)         [function]
+  // -----------------------------------------------
+  rule loadFile(Dir, Path)
+    => parseFile(#system("parser_PGM \"" +String Dir +String "/" +String Path +String "\""))
   rule parseFile(#systemResult(0, Stdout, _)) => #parseKORE(Stdout)
 ```
 

--- a/syntax.md
+++ b/syntax.md
@@ -670,6 +670,21 @@ Unit test files allow the following additional groups.
     syntax ParameterGroup ::= ParameterDecl
     ```
 
+-   `import` groups map test fragments in files to strings for future usage
+
+    ```k
+    syntax Group ::= ImportGroup
+    syntax ImportGroup ::= "import" String "as" String
+    ```
+
+-   `include` groups load either imported test fragments or raw files
+
+    ```k
+    syntax Group ::= IncludeGroup
+    syntax IncludeGroup ::= "include" String
+                          | "include-file" String
+    ```
+
 ```k
 endmodule
 ```

--- a/tests/lib/abs.tzt
+++ b/tests/lib/abs.tzt
@@ -1,0 +1,1 @@
+code { ABS }

--- a/tests/multi/include_00.tzt
+++ b/tests/multi/include_00.tzt
@@ -1,0 +1,1 @@
+include-file "tests/unit/abs_00.tzt"

--- a/tests/multi/include_00.tzt
+++ b/tests/multi/include_00.tzt
@@ -1,1 +1,1 @@
-include-file "tests/unit/abs_00.tzt"
+include-file "../unit/abs_00.tzt"

--- a/tests/multi/include_01.tzt
+++ b/tests/multi/include_01.tzt
@@ -1,3 +1,3 @@
 test "ABS" {
-  include-file "tests/unit/abs_00.tzt"
+  include-file "../unit/abs_00.tzt"
 }

--- a/tests/multi/include_01.tzt
+++ b/tests/multi/include_01.tzt
@@ -1,0 +1,3 @@
+test "ABS" {
+  include-file "tests/unit/abs_00.tzt"
+}

--- a/tests/multi/include_02.tzt
+++ b/tests/multi/include_02.tzt
@@ -1,4 +1,4 @@
-import "tests/unit/abs_00.tzt" as "ABS" ;
+import "../unit/abs_00.tzt" as "ABS" ;
 
 test "ABS" {
   include "ABS"

--- a/tests/multi/include_02.tzt
+++ b/tests/multi/include_02.tzt
@@ -1,0 +1,5 @@
+import "tests/unit/abs_00.tzt" as "ABS" ;
+
+test "ABS" {
+  include "ABS"
+}

--- a/tests/multi/include_03.tzt
+++ b/tests/multi/include_03.tzt
@@ -4,8 +4,7 @@ test "ABS00" {
   include "ABS" ;
   input { Stack_elt int -5 } ;
   output { Stack_elt nat 5 }
-}
-
+} ;
 
 test "ABS01" {
   input { Stack_elt int -10 } ;

--- a/tests/multi/include_03.tzt
+++ b/tests/multi/include_03.tzt
@@ -1,0 +1,14 @@
+import "tests/lib/abs.tzt" as "ABS" ;
+
+test "ABS00" {
+  include "ABS" ;
+  input { Stack_elt int -5 } ;
+  output { Stack_elt nat 5 }
+}
+
+
+test "ABS01" {
+  input { Stack_elt int -10 } ;
+  include "ABS" ;
+  output { Stack_elt nat 10 }
+}

--- a/tests/multi/include_03.tzt
+++ b/tests/multi/include_03.tzt
@@ -1,4 +1,4 @@
-import "tests/lib/abs.tzt" as "ABS" ;
+import "../lib/abs.tzt" as "ABS" ;
 
 test "ABS00" {
   include "ABS" ;


### PR DESCRIPTION
Currently, relative paths are interpreted relative to `./kmich` and not to the file which we are importing from.

This is not ideal, but I'm not sure of the best way to fix this.

My thought is we can merge this now and come back and fix this issue later. Thoughts?

Fixes: runtimeverification/firefly-michelson#16