### PR TITLE
Implement abstract state serialization

### DIFF
--- a/tests/proofs/dexter/dexter.md
+++ b/tests/proofs/dexter/dexter.md
@@ -17,7 +17,7 @@ We begin start our verification project by opening a new module context in which
 ```k
 requires "../lemmas.md"
 module DEXTER-VERIFICATION-SYNTAX
-  imports MICHELSON-COMMON-SYNTAX
+  imports MICHELSON-INTERNAL-SYNTAX
 endmodule
 ```
 
@@ -70,6 +70,13 @@ configuration <dexterTop>
 ```
 
 ## Entrypoint Summaries
+
+We define our list of entrypoints below.
+Each entrypoint is given a unique abstract parameter type that we use to simplify our proof structure.
+
+```k
+  syntax EntryPointParams
+```
 
 1.  [dexter.mligo.tz](https://gitlab.com/dexter2tz/dexter2tz/-/blob/8a5792a56e0143042926c3ca8bff7d7068a541c3/dexter.mligo.tz)
 
@@ -200,6 +207,108 @@ As reference materials for understanding the contract intent, we will consult:
 3.  The [Michelson documentation](http://tezos.gitlab.io/008/michelson.html)
 4.  The [FA 1.2 standard](https://gitlab.com/tzip/tzip/blob/master/proposals/tzip-7/tzip-7.md)
 5.  The [FA 2 standard](https://gitlab.com/tzip/tzip/-/blob/master/proposals/tzip-12/tzip-12.md)
+
+## State Abstraction
+
+We use a few helper routines to convert between our abstract and concrete proof state.
+We first define functions which build our parameter and our storage types.
+
+```k
+  syntax TypeName ::= #DexterParamType(EntryPointParams) [function, functional]
+  // --------------------------------------------------------------------------
+  // FIXME
+
+  syntax TypeName ::= #DexterStorageType(Bool)                [function, functional]
+                    | #DexterVersionSpecificStorageType(Bool) [function, functional]
+  // -------------------------------------------------------------------------------
+  rule #DexterStorageType(IsFA2)
+    => pair nat
+         pair mutez
+           pair nat
+             pair bool
+               pair bool
+                 pair address
+                   pair address
+                     #DexterVersionSpecificStorageType(IsFA2)
+
+  rule #DexterVersionSpecificStorageType(true)  => pair nat address
+  rule #DexterVersionSpecificStorageType(false) => address
+```
+
+We also define a functions that serialize and deserialize our abstract parameters and state.
+
+```k
+  syntax Data ::= #LoadDexterParams(EntryPointParams) [function, functional]
+  // -----------------------------------------------------------------------
+  // FIXME
+
+  syntax KItem ::= #loadDexterState(Bool, EntryPointParams)
+  // ------------------------------------------------------
+  rule <k> #loadDexterState(IsFA2, Params)
+        => .K
+           ...
+       </k>
+       <stack> .Stack
+            => [ pair #DexterParamType(Params) #DexterStorageType(IsFA2)
+                 Pair #LoadDexterParams(Params)
+                   Pair TokenPool
+                     Pair XTZPool
+                       Pair LQTTotal
+                         Pair IsUpdatingTokenPool
+                           Pair IsBakerFrozen
+                             Pair Manager
+                               Pair TokenAddress
+                                 #if IsFA2
+                                   #then Pair TokenId LQTAddress
+                                   #else LQTAddress
+                                 #fi ]
+       </stack>
+       <tokenPool>               TokenPool           </tokenPool>
+       <xtzPool>                 XTZPool             </xtzPool>
+       <lqtTotal>                LQTTotal            </lqtTotal>
+       <selfIsUpdatingTokenPool> IsUpdatingTokenPool </selfIsUpdatingTokenPool>
+       <freezeBaker>             IsBakerFrozen       </freezeBaker>
+       <manager>                 Manager             </manager>
+       <tokenAddress>            TokenAddress        </tokenAddress>
+       <tokenId>                 TokenId             </tokenId>
+       <lqtAddress>              LQTAddress          </lqtAddress>
+
+  syntax KItem ::= #storeDexterState(Bool)
+                 | #storeDexterState(Bool, Data)
+  // -------------------------------------------
+  rule <k> #storeDexterState(IsFA2)
+        => #storeDexterState(IsFA2, VersionSpecificData)
+           ...
+       </k>
+       <stack> [ pair list operation StorageType:TypeName
+                 Pair _OpList
+                   Pair TokenPool
+                     Pair XTZPool
+                       Pair LQTTotal
+                         Pair IsUpdatingTokenPool
+                           Pair IsBakerFrozen
+                             Pair Manager
+                               Pair TokenContract
+                                 VersionSpecificData ]
+       </stack>
+       <tokenPool>               _ => TokenPool           </tokenPool>
+       <xtzPool>                 _ => XTZPool             </xtzPool>
+       <lqtTotal>                _ => LQTTotal            </lqtTotal>
+       <selfIsUpdatingTokenPool> _ => IsUpdatingTokenPool </selfIsUpdatingTokenPool>
+       <freezeBaker>             _ => IsBakerFrozen       </freezeBaker>
+       <manager>                 _ => Manager             </manager>
+       <tokenAddress>            _ => TokenContract       </tokenAddress>
+    requires StorageType ==K #DexterStorageType(IsFA2)
+
+  rule <k> #storeDexterState(IsFA2, Pair TokenId LQTContract) => .K ... </k>
+       <tokenId>    _ => TokenId     </tokenId>
+       <lqtAddress> _ => LQTContract </lqtAddress>
+    requires IsFA2
+
+  rule <k> #storeDexterState(IsFA2, LQTContract) => .K ... </k>
+       <lqtAddress> _ => LQTContract </lqtAddress>
+    requires notBool IsFA2
+```
 
 ## Epilogue
 

--- a/tests/proofs/dexter/dexter.md
+++ b/tests/proofs/dexter/dexter.md
@@ -269,16 +269,13 @@ We first define functions which build our parameter and our storage types.
 We also define a functions that serialize and deserialize our abstract parameters and state.
 
 ```k
-  syntax Data ::= #LoadDexterParams(EntryPointParams) [function, functional]
-  // -----------------------------------------------------------------------
+  syntax Data ::= #LoadDexterParams(EntryPointParams) [function, functional, no-evaluators]
+  // --------------------------------------------------------------------------------------
   // FIXME
 
   syntax KItem ::= #loadDexterState(Bool, EntryPointParams)
   // ------------------------------------------------------
-  rule <k> #loadDexterState(IsFA2, Params)
-        => .K
-           ...
-       </k>
+  rule <k> #loadDexterState(IsFA2, Params) => . ... </k>
        <stack> .Stack
             => [ pair #DexterParamType(IsFA2) #DexterStorageType(IsFA2)
                  Pair #LoadDexterParams(Params)
@@ -307,10 +304,7 @@ We also define a functions that serialize and deserialize our abstract parameter
   syntax KItem ::= #storeDexterState(Bool)
                  | #storeDexterState(Bool, Data)
   // -------------------------------------------
-  rule <k> #storeDexterState(IsFA2)
-        => #storeDexterState(IsFA2, VersionSpecificData)
-           ...
-       </k>
+  rule <k> #storeDexterState(IsFA2) => #storeDexterState(IsFA2, VersionSpecificData) ... </k>
        <stack> [ pair list operation StorageType:TypeName
                  Pair _OpList
                    Pair TokenPool

--- a/tests/proofs/dexter/dexter.md
+++ b/tests/proofs/dexter/dexter.md
@@ -218,33 +218,33 @@ We first define functions which build our parameter and our storage types.
                     | #DexterVersionSpecificParamType(Bool) [function, functional]
   // -----------------------------------------------------------------------------
   rule #DexterParamType(IsFA2)
-    => or
-         or
-           or
-             or pair address                         // addLiquidity
-                  pair nat
-                    pair nat timestamp
-                unit                                 // default
-             or pair address                         // removeLiquidity
-                  pair nat
-                    pair mutez
-                      pair nat timestamp
-                pair option key_hash bool            // setBaker
-           or
-             or address                              // setLqtAddress
-                address                              // setManager
-             or pair address                         // tokenToToken
-                  pair nat
-                    pair address
-                      pair nat timestamp
-                pair address                         // tokenToXtz
-                  pair nat
-                    pair mutez timestamp
-         or
-           or unit                                   // updateTokenPool
-              #DexterVersionSpecificParamType(IsFA2) // updateTokenPoolInternal
-           pair address                              // xtzToToken
-             pair nat timestamp
+    => (or
+          (or
+             (or
+                (or (pair address                        // addLiquidity
+                       pair nat
+                         pair nat timestamp)
+                    unit)                                // default
+                (or (pair address                        // removeLiquidity
+                       pair nat
+                         pair mutez
+                           pair nat timestamp)
+                    (pair option key_hash bool)))        // setBaker
+             (or
+                (or address                              // setLqtAddress
+                    address)                             // setManager
+                (or (pair address                        // tokenToToken
+                       pair nat
+                         pair address
+                           pair nat timestamp)
+                    (pair address                        // tokenToXtz
+                       pair nat
+                         pair mutez timestamp))))
+          (or
+             (or unit                                    // updateTokenPool
+                 #DexterVersionSpecificParamType(IsFA2)) // updateTokenPoolInternal
+             (pair address                               // xtzToToken
+                pair nat timestamp)))
 
   rule #DexterVersionSpecificParamType(true)  => list pair pair address nat nat
   rule #DexterVersionSpecificParamType(false) => nat

--- a/tests/proofs/dexter/dexter.md
+++ b/tests/proofs/dexter/dexter.md
@@ -214,9 +214,40 @@ We use a few helper routines to convert between our abstract and concrete proof 
 We first define functions which build our parameter and our storage types.
 
 ```k
-  syntax TypeName ::= #DexterParamType(EntryPointParams) [function, functional]
-  // --------------------------------------------------------------------------
-  // FIXME
+  syntax TypeName ::= #DexterParamType(Bool)                [function, functional]
+                    | #DexterVersionSpecificParamType(Bool) [function, functional]
+  // -----------------------------------------------------------------------------
+  rule #DexterParamType(IsFA2)
+    => or
+         or
+           or
+             or pair address                         // addLiquidity
+                  pair nat
+                    pair nat timestamp
+                unit                                 // default
+             or pair address                         // removeLiquidity
+                  pair nat
+                    pair mutez
+                      pair nat timestamp
+                pair option key_hash bool            // setBaker
+           or
+             or address                              // setLqtAddress
+                address                              // setManager
+             or pair address                         // tokenToToken
+                  pair nat
+                    pair address
+                      pair nat timestamp
+                pair address                         // tokenToXtz
+                  pair nat
+                    pair mutez timestamp
+         or
+           or unit                                   // updateTokenPool
+              #DexterVersionSpecificParamType(IsFA2) // updateTokenPoolInternal
+           pair address                              // xtzToToken
+             pair nat timestamp
+
+  rule #DexterVersionSpecificParamType(true)  => list pair pair address nat nat
+  rule #DexterVersionSpecificParamType(false) => nat
 
   syntax TypeName ::= #DexterStorageType(Bool)                [function, functional]
                     | #DexterVersionSpecificStorageType(Bool) [function, functional]
@@ -249,7 +280,7 @@ We also define a functions that serialize and deserialize our abstract parameter
            ...
        </k>
        <stack> .Stack
-            => [ pair #DexterParamType(Params) #DexterStorageType(IsFA2)
+            => [ pair #DexterParamType(IsFA2) #DexterStorageType(IsFA2)
                  Pair #LoadDexterParams(Params)
                    Pair TokenPool
                      Pair XTZPool


### PR DESCRIPTION
This PR implements:

- Two functions relating to produce Michelson types (needed to produce a well-formed Michelson stack cell, which includes a type tag):

    - a function `#DexterParamType` which builds the contract parameter type in Michelson corresponding to the Dexter contract parameter type (in both the FA12 and FA2 versions)
    - a function `#DexterStorageType` which builds the contract storage type in Michelson corresponding to the Dexter contract storage type (in both the FA12 and FA2 versions)

- a conversion function from our abstract storage value + abstract parameter value into an initial Michelson stack input corresponding to the Dexter contract input (in both the FA12 and FA2 versions)
- a conversion function from the final Michelson stack cell data into the Dexter contract abstract storage configuration

To check that these functions are correct, you can compare the type structure in the contract with the type structure in the compiled versions of the Michelson contracts:

   - [dexter.mligo.tz](https://gitlab.com/dexter2tz/dexter2tz/-/blob/8a5792a56e0143042926c3ca8bff7d7068a541c3/dexter.mligo.tz) - the FA12 version
   - [dexter.fa2.mligo.tz](https://gitlab.com/dexter2tz/dexter2tz/-/blob/8a5792a56e0143042926c3ca8bff7d7068a541c3/dexter.fa2.mligo.tz) - the FA2 version
   
The relevant type information is contained in the `storage` and `parameter` declarations at the top of the respective files.

Fixes: #199 