### PR TITLE
Nice to haves

### DIFF
--- a/tests/proofs/dexter/dexter-compiled.md
+++ b/tests/proofs/dexter/dexter-compiled.md
@@ -64,9 +64,13 @@ Since we work with specific code that contains a finite number of annotations, w
          SWAP ;
          CAR ;
          IF_LEFT
+           // Left
            { IF_LEFT
+               // Left Left
                { IF_LEFT
+                   // Left Left Left
                    { IF_LEFT
+                       // Left Left Left Left
                        { DUP ;
                          CDR ;
                          SWAP ;
@@ -277,6 +281,7 @@ Since we work with specific code that contains a finite number of annotations, w
                                              DIG 2 ;
                                              CONS ;
                                              PAIR } } } } }
+                       // Left Left Left Right
                        { DROP ;
                          DUP ;
                          CDR ;
@@ -300,7 +305,9 @@ Since we work with specific code that contains a finite number of annotations, w
                               PAIR ;
                               NIL operation ;
                               PAIR } } }
+                   // Left Left Right
                    { IF_LEFT
+                       // Left Left Right Left
                        { DUP ;
                          CDR ;
                          SWAP ;
@@ -533,6 +540,7 @@ Since we work with specific code that contains a finite number of annotations, w
                                                   DIG 2 ;
                                                   CONS ;
                                                   PAIR } } } } } }
+                       // Left Left Right Right
                        { DUP ;
                          CDR ;
                          SWAP ;
@@ -611,8 +619,11 @@ Since we work with specific code that contains a finite number of annotations, w
                                              SET_DELEGATE ;
                                              CONS ;
                                              PAIR } } } } } } }
+               // Left Right
                { IF_LEFT
+                   // Left Right Left
                    { IF_LEFT
+                       // Left Right Left Left
                        { SWAP ;
                          DUP ;
                          DUG 2 ;
@@ -709,6 +720,7 @@ Since we work with specific code that contains a finite number of annotations, w
                                              PAIR ;
                                              NIL operation ;
                                              PAIR } } } } }
+                       // Left Right Left Right
                        { SWAP ;
                          DUP ;
                          DUG 2 ;
@@ -781,7 +793,9 @@ Since we work with specific code that contains a finite number of annotations, w
                                         PAIR ;
                                         NIL operation ;
                                         PAIR } } } } }
+                   // Left Right Right
                    { IF_LEFT
+                       // Left Right Right Left
                        { DUP ;
                          CDR ;
                          SWAP ;
@@ -936,6 +950,7 @@ Since we work with specific code that contains a finite number of annotations, w
                                         DIG 2 ;
                                         CONS ;
                                         PAIR } } } }
+                       // Left Right Right Right
                        { DUP ;
                          CDR ;
                          SWAP ;
@@ -1082,8 +1097,11 @@ Since we work with specific code that contains a finite number of annotations, w
                                         DIG 2 ;
                                         CONS ;
                                         PAIR } } } } } } }
+           // Right
            { IF_LEFT
+               // Right Left
                { IF_LEFT
+                   // Right Left Left
                    { DROP ;
                      SOURCE ;
                      SENDER ;
@@ -1149,6 +1167,7 @@ Since we work with specific code that contains a finite number of annotations, w
                                     DIG 2 ;
                                     CONS ;
                                     PAIR } } } }
+                   // Right Left Right
                    { SWAP ;
                      DUP ;
                      DUG 2 ;
@@ -1206,6 +1225,7 @@ Since we work with specific code that contains a finite number of annotations, w
                                PAIR ;
                                NIL operation ;
                                PAIR } } } }
+               // Right Right
                { DUP ;
                  CDR ;
                  SWAP ;

--- a/tests/proofs/dexter/dexter-compiled.md
+++ b/tests/proofs/dexter/dexter-compiled.md
@@ -2,12 +2,13 @@
 requires "../../../pretty-syntax.md"
 module DEXTER-COMPILED
   imports MICHELSON-PRETTY-SYNTAX
+  imports BOOL
 ```
 
 # Purpose
 
 This module contains the compiled Dexter code for version FA1.2 and FA2.
-The macros `#dexterCode` and `#dexterCodeFA2` translate to the respective Michelson code.
+The macros `#dexterCodeFA12` and `#dexterCodeFA2` translate to the respective Michelson code.
 We have pasted the code verbatim:
 https://gitlab.com/dexter2tz/dexter2tz/-/blob/8a5792a56e0143042926c3ca8bff7d7068a541c3/dexter.mligo.tz
 https://gitlab.com/dexter2tz/dexter2tz/-/blob/8a5792a56e0143042926c3ca8bff7d7068a541c3/dexter.fa2.mligo.tz
@@ -15,7 +16,11 @@ https://gitlab.com/dexter2tz/dexter2tz/-/blob/8a5792a56e0143042926c3ca8bff7d7068
 # The Dexter Smart Contract Code
 
 ```k
-  syntax Data ::= "#dexterCode" | "#dexterCodeFA2"
+  syntax Data ::= "#dexterCodeFA12" | "#dexterCodeFA2"
+  syntax Data ::= #dexterCode ( Bool ) [function, functional]
+
+  rule #dexterCode(IsFA2) => #dexterCodeFA2  requires         IsFA2
+  rule #dexterCode(IsFA2) => #dexterCodeFA12 requires notBool IsFA2
 ```
 
 ## Annotations
@@ -53,7 +58,7 @@ Since we work with specific code that contains a finite number of annotations, w
 ## FA1.2
 
 ```k
-  rule #dexterCode
+  rule #dexterCodeFA12
     => { DUP ;
          CDR ;
          SWAP ;

--- a/tests/proofs/dexter/dexter-compiled.md
+++ b/tests/proofs/dexter/dexter-compiled.md
@@ -17,7 +17,8 @@ https://gitlab.com/dexter2tz/dexter2tz/-/blob/8a5792a56e0143042926c3ca8bff7d7068
 
 ```k
   syntax Data ::= "#dexterCodeFA12" | "#dexterCodeFA2"
-  syntax Data ::= #dexterCode ( Bool ) [function, functional]
+                | #dexterCode ( Bool ) [function, functional]
+  // --------------------------------------------------------
 
   rule #dexterCode(IsFA2) => #dexterCodeFA2  requires         IsFA2
   rule #dexterCode(IsFA2) => #dexterCodeFA12 requires notBool IsFA2

--- a/tests/proofs/dexter/dexter-spec.md
+++ b/tests/proofs/dexter/dexter-spec.md
@@ -5,10 +5,13 @@ module DEXTER-SPEC
   claim <k> now 0 => . ... </k>
         <mynow> #Timestamp(0) </mynow>
 
-  claim <k> (now 0 => .) ~> #dexterCode ... </k>
+  claim <k> (now 0 => .) ~> #dexterCode(true) ... </k>
         <mynow> #Timestamp(0) </mynow>
 
-  claim <k> (now 0 => .) ~> #dexterCodeFA2 ... </k>
+  claim <k> (now 0 => .) ~> #dexterCode(false) ... </k>
+        <mynow> #Timestamp(0) </mynow>
+
+  claim <k> (now 0 => .) ~> #dexterCode(_) ... </k>
         <mynow> #Timestamp(0) </mynow>
 
 endmodule


### PR DESCRIPTION
- Annotating the Dexter code with Left/Right entry points.
- A function for choosing between the two code macros, so we can write a single spec for both versions in the cases where the version doesn't matter.

```
claim <k> #dexterCode(IsFA2) => . ... </k>
          <storage> [...] </storage>
```
