### PR TITLE
Simplify Dexter proof claims

### DIFF
--- a/tests/proofs/dexter/dexter-spec.md
+++ b/tests/proofs/dexter/dexter-spec.md
@@ -27,7 +27,6 @@ The contract sets its manager to the provided manager address if the following c
 
 ```k
   claim <k> #runProof(_IsFA2, SetManager(NewManager)) => . </k>
-        <stack> .Stack </stack>
         <manager> Sender => NewManager </manager>
         <selfIsUpdatingTokenPool> false </selfIsUpdatingTokenPool>
         <myamount> #Mutez(Amount) </myamount>
@@ -60,7 +59,6 @@ The contract sets its delegate to the value of `baker` (and optionally freezes t
 
 ```k
   claim <k> #runProof(_IsFA2, SetBaker(Baker, FreezeBaker)) => . </k>
-        <stack> .Stack </stack>
         <manager> Sender </manager>
         <selfIsUpdatingTokenPool> false </selfIsUpdatingTokenPool>
         <myamount> #Mutez(Amount) </myamount>
@@ -98,7 +96,6 @@ The contract sets its liquidity pool adddress to the provided address if the fol
 
 ```k
   claim <k> #runProof(_IsFA2, SetLQTAddress(NewLQTAddress)) => . </k>
-        <stack> .Stack </stack>
         <manager> Sender </manager>
         <selfIsUpdatingTokenPool> false </selfIsUpdatingTokenPool>
         <myamount> #Mutez(Amount) </myamount>
@@ -112,7 +109,6 @@ If any of the conditions are not satisfied, the call fails.
 
 ```k
   claim <k> #runProof(_IsFA2, SetLQTAddress(_NewLQTAddress)) => Aborted(?_, ?_, ?_, ?_) </k>
-        <stack> .Stack => ( Failed ?_ ) </stack>
         <manager> CurrentManager </manager>
         <selfIsUpdatingTokenPool> IsUpdating </selfIsUpdatingTokenPool>
         <myamount> #Mutez(Amount) </myamount>
@@ -133,7 +129,6 @@ Adds more money to the xtz reserves if the following conditions are satisifed:
 
 ```k
   claim <k> #runProof(_IsFA2, Default) => . </k>
-        <stack> .Stack </stack>
         <selfIsUpdatingTokenPool> false </selfIsUpdatingTokenPool>
         <myamount> #Mutez(Amount) </myamount>
         <xtzPool> #Mutez(XtzPool => XtzPool +Int Amount) </xtzPool>

--- a/tests/proofs/dexter/dexter.md
+++ b/tests/proofs/dexter/dexter.md
@@ -579,6 +579,12 @@ We also define a functions that serialize and deserialize our abstract parameter
        <tokenAddress>            TokenAddress        </tokenAddress>
        <tokenId>                 TokenId             </tokenId>
        <lqtAddress>              LQTAddress          </lqtAddress>
+       <myamount>                TxnAmount           </myamount>
+    ensures TokenPool >=Int 0
+    andBool #Mutez(_:Int) :=K XTZPool andBool #IsLegalMutezValue(XTZPool)
+    andBool LQTTotal >=Int 0
+    andBool TokenId >=Int 0
+    andBool #Mutez(_:Int) :=K TxnAmount andBool #IsLegalMutezValue(TxnAmount)
 
   syntax KItem ::= #storeDexterState(Bool)
                  | #storeDexterState(Bool, Data)
@@ -605,6 +611,7 @@ We also define a functions that serialize and deserialize our abstract parameter
        <tokenAddress>            _ => TokenContract       </tokenAddress>
        <operations>              _ => OpList              </operations>
     requires StorageType ==K #DexterStorageType(IsFA2)
+     andBool #IsLegalMutezValue(XTZPool)
 
   rule <k> #storeDexterState(IsFA2, Pair TokenId LQTContract) => .K ... </k>
        <tokenId>    _ => TokenId     </tokenId>

--- a/tests/proofs/dexter/dexter.md
+++ b/tests/proofs/dexter/dexter.md
@@ -555,7 +555,7 @@ We also define a functions that serialize and deserialize our abstract parameter
   syntax KItem ::= #loadDexterState(Bool, EntryPointParams)
   // ------------------------------------------------------
   rule <k> #loadDexterState(IsFA2, Params) => . ... </k>
-       <stack> .Stack
+       <stack> SS:InternalStack
             => [ pair #DexterParamType(IsFA2) #DexterStorageType(IsFA2)
                  Pair #LoadDexterParams(IsFA2, Params)
                    Pair TokenPool
@@ -569,6 +569,7 @@ We also define a functions that serialize and deserialize our abstract parameter
                                    #then Pair TokenId LQTAddress
                                    #else LQTAddress
                                  #fi ]
+             ; .Stack
        </stack>
        <tokenPool>               TokenPool           </tokenPool>
        <xtzPool>                 XTZPool             </xtzPool>
@@ -580,7 +581,8 @@ We also define a functions that serialize and deserialize our abstract parameter
        <tokenId>                 TokenId             </tokenId>
        <lqtAddress>              LQTAddress          </lqtAddress>
        <myamount>                TxnAmount           </myamount>
-    ensures TokenPool >=Int 0
+    ensures SS ==K .Stack
+    andBool TokenPool >=Int 0
     andBool #Mutez(_:Int) :=K XTZPool andBool #IsLegalMutezValue(XTZPool)
     andBool LQTTotal >=Int 0
     andBool TokenId >=Int 0


### PR DESCRIPTION
This PR uses an `ensures` clause on the `#loadDexterState` to force the initial state to be well-formed, including for cells which are not directly mentioned in the proof.

It similarly uses a `requires` clause on `#storeDexterState` to ensure that the final state is well-formed.