### PR TITLE
Simplify comparison reasoning for the prover

### DIFF
--- a/common.md
+++ b/common.md
@@ -226,7 +226,8 @@ The internal representation of mutez is bounded.
   // --------------------------------------------
   rule #MutezOverflowLimit => 2 ^Int 63 // Signed 64 bit integers.
 
-  syntax Bool ::= #IsLegalMutezValue(Mutez) [function, functional]
+  syntax Bool ::= #IsLegalMutezValue(Int)   [function, functional]
+                | #IsLegalMutezValue(Mutez) [function, functional]
  // --------------------------------------------------------------
   rule #IsLegalMutezValue(I)         => I >=Int 0 andBool I <Int #MutezOverflowLimit
   rule #IsLegalMutezValue(#Mutez(I)) => #IsLegalMutezValue(I)
@@ -595,10 +596,11 @@ elements.
        Create_contract
            { C }
            {#MichelineToNative(O, (option .AnnotationList  key_hash .AnnotationList), KnownAddrs, BigMaps)}:>OptionData
-           {#MichelineToNative(M, mutez .AnnotationList, KnownAddrs, BigMaps)}:>Mutez
+           M
            #MichelineToNative(S, #StorageTypeFromContract(C), KnownAddrs, BigMaps)
            N
     requires (isWildcard(N) orBool isInt(N))
+     andBool #IsLegalMutezValue(M)
 
   rule #MichelineToNative(Set_delegate K N, operation _, KnownAddrs, BigMaps) =>
        Set_delegate {#MichelineToNative(K, (option .AnnotationList key_hash .AnnotationList), KnownAddrs, BigMaps)}:>OptionData N
@@ -624,11 +626,12 @@ a contract lookup.
                   KnownAddrs,
                   BigMaps
               )
-              {#MichelineToNative(M, mutez .AnnotationList, KnownAddrs, BigMaps)}:>Mutez
+              M
               #ParseEntrypoint(A)
               N
        requires (isWildcard(N) orBool isInt(N))
         andBool #ParseEntrypoint(A) in_keys(KnownAddrs)
+        andBool #IsLegalMutezValue(M)
 ```
 
 We extract a `big_map` by index from the bigmaps map. Note that these have

--- a/compat.md
+++ b/compat.md
@@ -24,6 +24,7 @@ module MICHELSON-UNPARSER
   // We add sorts here to simplify when terms are primitive arguments
   syntax ApplicationData ::= Pair | OrData | OptionData
   syntax Data ::= ApplicationData
+  syntax Data ::= Entrypoint
 
   // Michelson IR Unparsing Entrypoint
   syntax String ::= #unparse(K) [function]
@@ -114,9 +115,10 @@ module MICHELSON-UNPARSER
   rule #doUnparse(#KeyHash(S), _) => #doUnparse(S, false)
   rule #doUnparse(#Mutez(I), _) => #doUnparse(I, false)
   rule #doUnparse(#Address(S), _) => #doUnparse(S, false)
-  rule #doUnparse(#Contract(A, _), _) => #doUnparse(A, false)
+  rule #doUnparse(#Contract(A, _), _) => #doUnparse(#ToString(A), false)
   rule #doUnparse(#Key(S), _) => #doUnparse(S, false)
   rule #doUnparse(#Signature(S), _) => #doUnparse(S, false)
+  rule #doUnparse(EP:Entrypoint, _) => #doUnparse(#ToString(EP), false)
 
   // Unparse types.
 
@@ -466,7 +468,7 @@ The following macros are currently disabled.
     " " +String
     #doUnparse(I, true)
 
-  rule #doUnparse(Transfer_tokens O M A I, _) =>
+  rule #doUnparse(Transfer_tokens O M A:Entrypoint I, _) =>
     "Transfer_tokens " +String
     #doUnparse(O, true) +String
     " " +String
@@ -805,7 +807,7 @@ module OUTPUT-COMPARE
        </out> [owise]
 
   rule <k> other_contracts { M } ; Gs => Gs </k>
-       <knownaddrs> _ => #OtherContractsMapEntryListToKMap(M) </knownaddrs>
+       <knownaddrs> _ => #OtherContractsMapToKMap(M) </knownaddrs>
 
   rule <k> real_output AOS ; output EOS => #CheckOutput(EOS, AOS) ... </k>
 endmodule

--- a/compat.md
+++ b/compat.md
@@ -478,6 +478,16 @@ The following macros are currently disabled.
     " " +String
     #doUnparse(I, true)
 
+  rule #doUnparse(Transfer_tokens O M A:String I, _) =>
+    "Transfer_tokens " +String
+    #doUnparse(O, true) +String
+    " " +String
+    #doUnparse(M, true) +String
+    " " +String
+    #doUnparse(A, true) +String
+    " " +String
+    #doUnparse(I, true)
+
   rule #doUnparse(Set_delegate O I, _) =>
     "Set_delegate " +String
     #doUnparse(O, true) +String

--- a/compat.md
+++ b/compat.md
@@ -381,7 +381,7 @@ The following macros are currently disabled.
     "Contract " +String
     #doUnparse(S, false) +String
     " " +String
-    #doUnparse(T, false)
+    #doUnparse(T, true)
 
   rule #doUnparse(O:OtherContractsMapEntry ; O':OtherContractsMapEntry ; Os:OtherContractsMapEntryList, _) =>
     #doUnparse(O, false) +String

--- a/michelson.md
+++ b/michelson.md
@@ -1630,11 +1630,16 @@ These instructions push blockchain state on the stack.
   rule <k> SELF AL:AnnotationList => . ... </k>
        <stack> SS
             => [contract #LocalEntrypoint(AnnotMap, AL)
-                #Contract(A . #GetFieldAnnot(AL), #LocalEntrypoint(AnnotMap, AL))]
+                #Contract(#AddressToString(A) . #GetFieldAnnot(AL), #LocalEntrypoint(AnnotMap, AL))]
              ; SS
        </stack>
-       <paramtype> AnnotMap </paramtype>
-       <myaddr> #Address(A) </myaddr>
+       <paramtype> AnnotMap:Map </paramtype>
+       <myaddr> A </myaddr>
+
+  syntax String ::= #AddressToString(Address) [function, functional]
+  // ---------------------------------------------------------------
+  rule #AddressToString(#Address(S:String)) => S
+  rule #AddressToString(S:String)           => S
 
   rule <k> AMOUNT _A => . ... </k>
        <stack> SS => [mutez M] ; SS </stack>

--- a/michelson.md
+++ b/michelson.md
@@ -1071,7 +1071,12 @@ We define `COMPARE` in terms of a `#DoCompare` function.
 The `#DoCompare` function requires additional lemmas for symbolic execution.
 
 ```symbolic
-  rule #DoCompare(V, V) => 0 [simplification]
+  rule #DoCompare         (V, V) => 0 [simplification]
+  rule #DoCompareAddr     (V, V) => 0 [simplification]
+  rule #DoCompareBytes    (V, V) => 0 [simplification]
+  rule #DoCompareKeyHash  (V, V) => 0 [simplification]
+  rule #DoCompareTimestamp(V, V) => 0 [simplification]
+  rule #DoCompareMutez    (V, V) => 0 [simplification]
 
   rule 0 ==Int  #DoCompare(V1, V2) => V1  ==K V2  [simplification]
   rule 0 =/=Int #DoCompare(V1, V2) => V1 =/=K V2  [simplification]

--- a/michelson.md
+++ b/michelson.md
@@ -1585,7 +1585,7 @@ however forces us to use two rules for each operation.
 
   rule <k> TRANSFER_TOKENS _A => . ... </k>
        <stack> [T D] ; [mutez #Mutez(M)] ; [contract T #Contract(A, T)] ; SS
-            => [operation Transfer_tokens D M A O] ; SS
+            => [operation Transfer_tokens D #Mutez(M) A O] ; SS
        </stack>
        <nonce> #Nonce(O) => #NextNonce(#Nonce(O)) </nonce>
 
@@ -1607,8 +1607,8 @@ These instructions push fresh `contract` literals on the stack corresponding
 to the given addresses/key hashes.
 
 ```k
-  rule <k> CONTRACT AL T => . ... </k>
-       <stack> [address #Address(A:String)]
+  rule <k> CONTRACT AL:AnnotationList T => . ... </k>
+       <stack> [address A:Address]
              ; SS
             => [option contract #Name(T)
                 Some #Contract(A . #GetFieldAnnot(AL), { #RemoteEntrypointFromAnnots(ContractMap, A, AL) }:>TypeName)]
@@ -1623,7 +1623,7 @@ to the given addresses/key hashes.
 
   rule <k> IMPLICIT_ACCOUNT _AL => . ... </k>
        <stack> [key_hash #KeyHash(A)] ; SS
-            => [contract unit #Contract(A . %default, unit)] ; SS
+            => [contract unit #Contract(#Address(A) . %default, unit)] ; SS
        </stack>
 ```
 
@@ -1635,7 +1635,7 @@ These instructions push blockchain state on the stack.
        <mybalance> B </mybalance>
 
   rule <k> ADDRESS _AL => . ... </k>
-       <stack> [contract T #Contract(A . _, T)] ; SS => [address #Address(A)] ; SS </stack>
+       <stack> [contract T #Contract(A . _, T)] ; SS => [address A] ; SS </stack>
 
   rule <k> SOURCE _AL => . ... </k>
        <stack> SS => [address A] ; SS </stack>
@@ -1648,16 +1648,11 @@ These instructions push blockchain state on the stack.
   rule <k> SELF AL:AnnotationList => . ... </k>
        <stack> SS
             => [contract #LocalEntrypoint(AnnotMap, AL)
-                #Contract(#AddressToString(A) . #GetFieldAnnot(AL), #LocalEntrypoint(AnnotMap, AL))]
+                #Contract(A . #GetFieldAnnot(AL), #LocalEntrypoint(AnnotMap, AL))]
              ; SS
        </stack>
        <paramtype> AnnotMap:Map </paramtype>
        <myaddr> A </myaddr>
-
-  syntax String ::= #AddressToString(Address) [function, functional]
-  // ---------------------------------------------------------------
-  rule #AddressToString(#Address(S:String)) => S
-  rule #AddressToString(S:String)           => S
 
   rule <k> AMOUNT _A => . ... </k>
        <stack> SS => [mutez M] ; SS </stack>
@@ -2399,7 +2394,7 @@ It has an untyped and typed variant.
   rule <k> #MakeFresh(set       _:AnnotationList _:Type)        => ?_:Set                                              ... </k>
   rule <k> #MakeFresh(map       _:AnnotationList _:Type _:Type) => ?_:Map                                              ... </k>
   rule <k> #MakeFresh(big_map   _:AnnotationList _:Type _:Type) => ?_:Map                                              ... </k>
-  rule <k> #MakeFresh(contract  _:AnnotationList T)             => #Contract(?_:String . ?_:FieldAnnotation, #Name(T)) ... </k>
+  rule <k> #MakeFresh(contract  _:AnnotationList T)             => #Contract(#Address(?_:String ) . ?_:FieldAnnotation, #Name(T)) ... </k>
 
   rule <k> #MakeFresh(pair _:AnnotationList T1 T2)
         => (Pair #MakeFresh(T1) #MakeFresh(T2))

--- a/michelson.md
+++ b/michelson.md
@@ -64,15 +64,15 @@ The values of many of these cells are accessible via Michelson instructions.
         <bigmaps> .Map </bigmaps>
 
         <myaddr> #Address("InvalidMyAddr") </myaddr>
-        <paramtype> #NotSet </paramtype>
-        <storagetype> #NotSet </storagetype>
-        <script> #NoData </script>
+        <paramtype> .Map </paramtype>
+        <storagetype> .Type </storagetype>
+        <script> .Data </script>
 
-        <storagevalue> #NoData </storagevalue>
+        <storagevalue> .Data </storagevalue>
         <mybalance> #Mutez(0) </mybalance>
         <nonce> #Nonce(0) </nonce>
 
-        <paramvalue> #NoData </paramvalue>
+        <paramvalue> .Data </paramvalue>
         <myamount> #Mutez(0) </myamount>
         <sourceaddr> #Address("InvalidSourceAddr") </sourceaddr>
         <senderaddr> #Address("InvalidSenderAddr") </senderaddr>
@@ -199,14 +199,17 @@ Below are the rules for loading specific groups.
 #### Default Contract Groups
 
 ```k
-  rule <k> parameter T => .K ... </k>
-       <paramtype> #NotSet => T </paramtype>
+  rule <k> parameter T:Type => .K ... </k>
+       <paramtype> .Map => #BuildAnnotationMap(.FieldAnnotation, T) </paramtype>
+
+  rule <k> parameter FA:FieldAnnotation T:Type => .K ... </k>
+       <paramtype> .Map => #BuildAnnotationMap(FA, T) </paramtype>
 
   rule <k> storage T => .K ... </k>
-       <storagetype> #NotSet => T </storagetype>
+       <storagetype> .Type => T </storagetype>
 
   rule <k> code C => .K ... </k>
-       <script> #NoData => C </script>
+       <script> .Data => C </script>
 
   rule <k> G:Group ; Gs:Groups => G:Group ~> Gs ... </k>
 ```
@@ -238,7 +241,7 @@ Below are the rules for loading specific groups.
     requires #IsLegalMutezValue(I)
 
   rule <k> other_contracts { M } => .K ... </k>
-       <knownaddrs> .Map => #OtherContractsMapEntryListToKMap(M) </knownaddrs>
+       <knownaddrs> .Map => #OtherContractsMapToKMap(M) </knownaddrs>
 
   rule <k> big_maps { M } => .K ... </k>
        <bigmaps> .Map => #BigMapsEntryListToKMap(M) </bigmaps>
@@ -323,13 +326,13 @@ The following unit test groups are not supported by the symbolic interpreter.
 ```k
   syntax KItem ::= "#ConvertParamToNative"
   rule <k> #ConvertParamToNative => .K ... </k>
-       <paramvalue> D:Data => #MichelineToNative(D, #ConvertToType(T), .Map, BigMaps) </paramvalue>
-       <paramtype>  T      => #ConvertToType(T)                                       </paramtype>
+       <paramvalue> D:Data => #MichelineToNative(D, { #AddDefaultEntry(TypeMap, #Type(unit)) [ %default ] }:>Type, .Map, BigMaps) </paramvalue>
+       <paramtype> TypeMap => #AddDefaultEntry(TypeMap, #Type(unit)) </paramtype>
        <bigmaps> BigMaps </bigmaps>
 
   rule <k> #ConvertParamToNative => .K ... </k>
-       <paramvalue> #NoData                </paramvalue>
-       <paramtype>  T => #ConvertToType(T) </paramtype>
+       <paramvalue> .Data </paramvalue>
+       <paramtype> TypeMap => #AddDefaultEntry(TypeMap, #Type(unit)) </paramtype>
 
   syntax KItem ::= "#ConvertStorageToNative"
   rule <k> #ConvertStorageToNative => .K ... </k>
@@ -338,11 +341,11 @@ The following unit test groups are not supported by the symbolic interpreter.
        <bigmaps> BigMaps </bigmaps>
 
   rule <k> #ConvertStorageToNative => .K ... </k>
-       <storagevalue> #NoData                </storagevalue>
+       <storagevalue> .Data                </storagevalue>
        <storagetype>  T => #ConvertToType(T) </storagetype>
 
-  syntax Type ::= #ConvertToType(PreType) [function]
-  rule #ConvertToType(#NotSet) => unit .AnnotationList
+  syntax Type ::= #ConvertToType(MaybeType) [function]
+  rule #ConvertToType(.Type)   => unit .AnnotationList
   rule #ConvertToType(T:Type)  => T
 ```
 
@@ -461,7 +464,7 @@ version.
 
   syntax KItem ::= "#ExecuteScript"
   rule <k> #ExecuteScript
-        => #if Script ==K #NoData #then {} #else Script #fi
+        => #if Script ==K .Data #then {} #else Script #fi
            ...
        </k>
        <script> Script </script>
@@ -1563,7 +1566,7 @@ however forces us to use two rules for each operation.
        <nonce> #Nonce(O) => #NextNonce(#Nonce(O)) </nonce>
 
   rule <k> TRANSFER_TOKENS _A => . ... </k>
-       <stack> [T D] ; [mutez M] ; [contract T #Contract(A, _)] ; SS
+       <stack> [T D] ; [mutez M] ; [contract T #Contract(A, T)] ; SS
             => [operation Transfer_tokens D M A O] ; SS
        </stack>
        <nonce> #Nonce(O) => #NextNonce(#Nonce(O)) </nonce>
@@ -1586,11 +1589,15 @@ These instructions push fresh `contract` literals on the stack corresponding
 to the given addresses/key hashes.
 
 ```k
-  rule <k> CONTRACT _AL T => . ... </k>
-       <stack> [address A] ; SS => [option contract #Name(T) Some {M[A]}:>Data] ; SS </stack>
-       <knownaddrs> M </knownaddrs>
-    requires A in_keys(M)
-     andBool #TypeFromContractStruct({M[A]}:>Data) ==K T
+  rule <k> CONTRACT AL T => . ... </k>
+       <stack> [address #Address(A:String)]
+             ; SS
+            => [option contract #Name(T)
+                Some #Contract(A . #GetFieldAnnot(AL), { #RemoteEntrypointFromAnnots(ContractMap, A, AL) }:>TypeName)]
+             ; SS
+       </stack>
+       <knownaddrs> ContractMap </knownaddrs>
+    requires #RemoteEntrypointFromAnnots(ContractMap, A, AL) ==K #Name(T)
 
   rule <k> CONTRACT _AL T => . ... </k>
        <stack> [address _] ; SS => [option contract #Name(T) None] ; SS </stack>
@@ -1598,11 +1605,8 @@ to the given addresses/key hashes.
 
   rule <k> IMPLICIT_ACCOUNT _AL => . ... </k>
        <stack> [key_hash #KeyHash(A)] ; SS
-            => [contract unit #Contract(#Address(A), unit .AnnotationList)] ; SS
+            => [contract unit #Contract(A . %default, unit)] ; SS
        </stack>
-
-  syntax Type ::= #TypeFromContractStruct(Data) [function]
-  rule #TypeFromContractStruct(#Contract(_, T)) => T
 ```
 
 These instructions push blockchain state on the stack.
@@ -1613,8 +1617,7 @@ These instructions push blockchain state on the stack.
        <mybalance> B </mybalance>
 
   rule <k> ADDRESS _AL => . ... </k>
-       <stack> [contract TN #Contract(A, T)] ; SS => [address A] ; SS </stack>
-    requires TN ==K #Name(T)
+       <stack> [contract T #Contract(A . _, T)] ; SS => [address #Address(A)] ; SS </stack>
 
   rule <k> SOURCE _AL => . ... </k>
        <stack> SS => [address A] ; SS </stack>
@@ -1624,10 +1627,14 @@ These instructions push blockchain state on the stack.
        <stack> SS => [address A] ; SS </stack>
        <senderaddr> A </senderaddr>
 
-  rule <k> SELF _AL => . ... </k>
-       <stack> SS => [contract #Name(T) #Contract(A, T)] ; SS </stack>
-       <paramtype> T </paramtype>
-       <myaddr> A </myaddr>
+  rule <k> SELF AL:AnnotationList => . ... </k>
+       <stack> SS
+            => [contract #LocalEntrypoint(AnnotMap, AL)
+                #Contract(A . #GetFieldAnnot(AL), #LocalEntrypoint(AnnotMap, AL))]
+             ; SS
+       </stack>
+       <paramtype> AnnotMap </paramtype>
+       <myaddr> #Address(A) </myaddr>
 
   rule <k> AMOUNT _A => . ... </k>
        <stack> SS => [mutez M] ; SS </stack>
@@ -1940,7 +1947,7 @@ abstract out pieces of the stack which are non-invariant during loop execution.
 ```k
   syntax Instruction ::= "BIND" OutputStack Block
   rule <k> BIND Shape Block
-        => #Bind(#LiteralStackToStack(Shape), Stack)
+        => #Bind(Shape, Stack)
         ~> Block
         ~> #RestoreSymbols(Symbols)
            ...
@@ -1950,37 +1957,40 @@ abstract out pieces of the stack which are non-invariant during loop execution.
 ```
 
 ```k
-  syntax KItem ::= #Bind(InternalStack, InternalStack)
+  syntax KItem ::= #Bind(OutputStack, InternalStack)
 
-  rule <k> #Bind(.Stack, .Stack) => .K ... </k>
+  rule <k> #Bind({ .StackElementList }, .Stack) => .K ... </k>
 
   rule <k> #Bind(S1:FailedStack, S2:FailedStack) => .K ... </k>
     requires #Matches(S1, S2)
 
-  rule <k> #Bind( [ T S:SymbolicData ] ; SS  => SS
-                , [ T D ]              ; SS' => SS'
+  rule <k> #Bind( { Stack_elt T S:SymbolicData ; SS  => SS }
+                ,   [ TN D ]                   ; SS' => SS'
                 )
            ...
        </k>
-       <symbols> Syms => S |-> #TypedSymbol(T, D) Syms </symbols>
+       <symbols> Syms => S |-> #TypedSymbol(TN, D) Syms </symbols>
     requires notBool S in_keys(Syms)
+     andBool TN ==K #Name(T)
 
-  rule <k> #Bind( [ T S:SymbolicData ] ; SS  => SS
-                , [ T D1 ]             ; SS' => SS'
+  rule <k> #Bind( { Stack_elt T S:SymbolicData ; SS  => SS }
+                ,   [ TN D1 ]                  ; SS' => SS'
                 )
            ...
        </k>
-       <symbols> S |-> #TypedSymbol(T, D2) ... </symbols>
+       <symbols> S |-> #TypedSymbol(TN, D2) ... </symbols>
     requires D1 ==K D2
+     andBool TN ==K #Name(T)
 
-  rule <k> #Bind( [ T ED ] ; SS  => SS
-                , [ T AD ] ; SS' => SS'
+  rule <k> #Bind( { Stack_elt T ED ; SS  => SS }
+                ,   [ TN AD ]      ; SS' => SS'
                 )
            ...
        </k>
        <knownaddrs> KnownAddrs </knownaddrs>
        <bigmaps> BigMaps </bigmaps>
-    requires #ConcreteMatch(ED, #Type(T), KnownAddrs, BigMaps, AD)
+    requires #ConcreteMatch(ED, T, KnownAddrs, BigMaps, AD)
+     andBool TN ==K #Name(T)
 
   // NOTE: this function protects against unification errors
   syntax Bool ::= #ConcreteMatch(Data, Type, Map, Map, Data) [function]
@@ -2306,9 +2316,9 @@ It has an untyped and typed variant.
   rule isValue(chain_id,  #ChainId(_:Bytes))     => true
   rule isValue(operation, _:BlockchainOperation) => true
 
-  rule isValue(contract T, #Contract(#Address(_:String),TY)) => true requires T ==K #Name(TY)
-  rule isValue(option _, None)                               => true
-  rule isValue(option T, Some V)                             => isValue(T, V)
+  rule isValue(contract T, #Contract(_:Entrypoint,T)) => true
+  rule isValue(option _, None)                        => true
+  rule isValue(option T, Some V)                      => isValue(T, V)
 
   rule isValue(pair T1 T2, Pair LV RV)                => isValue(T1, LV) andBool isValue(T2, RV)
   rule isValue(or  T1 _T2, Left  V)                   => isValue(T1, V)
@@ -2362,11 +2372,11 @@ It has an untyped and typed variant.
   // TODO: should we expand into the three separate kinds of Blockchain operations?
   rule <k> #MakeFresh(operation _:AnnotationList) => ?_:BlockchainOperation ... </k>
 
-  rule <k> #MakeFresh(list      _:AnnotationList _:Type)        => ?_:InternalList                       ... </k>
-  rule <k> #MakeFresh(set       _:AnnotationList _:Type)        => ?_:Set                                ... </k>
-  rule <k> #MakeFresh(map       _:AnnotationList _:Type _:Type) => ?_:Map                                ... </k>
-  rule <k> #MakeFresh(big_map   _:AnnotationList _:Type _:Type) => ?_:Map                                ... </k>
-  rule <k> #MakeFresh(contract  _:AnnotationList T)             => #Contract(#Address(?_:String),T)      ... </k>
+  rule <k> #MakeFresh(list      _:AnnotationList _:Type)        => ?_:InternalList                                     ... </k>
+  rule <k> #MakeFresh(set       _:AnnotationList _:Type)        => ?_:Set                                              ... </k>
+  rule <k> #MakeFresh(map       _:AnnotationList _:Type _:Type) => ?_:Map                                              ... </k>
+  rule <k> #MakeFresh(big_map   _:AnnotationList _:Type _:Type) => ?_:Map                                              ... </k>
+  rule <k> #MakeFresh(contract  _:AnnotationList T)             => #Contract(?_:String . ?_:FieldAnnotation, #Name(T)) ... </k>
 
   rule <k> #MakeFresh(pair _:AnnotationList T1 T2)
         => (Pair #MakeFresh(T1) #MakeFresh(T2))
@@ -2460,12 +2470,12 @@ module MATCHER
        #Matches(M1, M2) andBool
        #Matches(D1, D2)
 
-  rule #Matches(Transfer_tokens D1 M1 A1 I1,
-                Transfer_tokens D2 M2 A2 I2)
+  rule #Matches(Transfer_tokens D1 M1 A1:Entrypoint I1,
+                Transfer_tokens D2 M2 A2:Entrypoint I2)
     => #Matches(I1, I2) andBool
        #Matches(D1, D2) andBool
        #Matches(M1, M2) andBool
-       #Matches(A1, A2)
+       A1 ==K A2
 
   rule #Matches(Set_delegate O1 I1,
                 Set_delegate O2 I2)

--- a/michelson.md
+++ b/michelson.md
@@ -1556,7 +1556,7 @@ however forces us to use two rules for each operation.
 ```k
   rule <k> CREATE_CONTRACT _:AnnotationList { C } => . ... </k>
        <stack> [option key_hash Delegate:OptionData] ;
-               [mutez Initial:Mutez] ;
+               [mutez #Mutez(Initial)] ;
                [_ Storage:Data] ;
                SS
             => [operation Create_contract { C } Delegate Initial Storage O ] ;
@@ -1566,7 +1566,7 @@ however forces us to use two rules for each operation.
        <nonce> #Nonce(O) => #NextNonce(#Nonce(O)) </nonce>
 
   rule <k> TRANSFER_TOKENS _A => . ... </k>
-       <stack> [T D] ; [mutez M] ; [contract T #Contract(A, T)] ; SS
+       <stack> [T D] ; [mutez #Mutez(M)] ; [contract T #Contract(A, T)] ; SS
             => [operation Transfer_tokens D M A O] ; SS
        </stack>
        <nonce> #Nonce(O) => #NextNonce(#Nonce(O)) </nonce>

--- a/syntax.md
+++ b/syntax.md
@@ -170,6 +170,7 @@ limitations.
   syntax CodeDecl ::= "code" Block
   syntax StorageDecl ::= "storage" Type
   syntax ParameterDecl ::= "parameter" Type
+                         | "parameter" FieldAnnotation Type
 
   syntax Contract ::= CodeDecl ";" StorageDecl ";" ParameterDecl ";"
                     | CodeDecl ";" ParameterDecl ";" StorageDecl ";"

--- a/syntax.md
+++ b/syntax.md
@@ -107,6 +107,9 @@ Simple data literals have efficiently detectable normal forms at runtime.
   syntax SimpleData ::= Mutez
   syntax SimpleData ::= Address
   syntax Data ::= SimpleData
+
+  syntax Address
+  syntax Mutez
 ```
 
 This declaration instructs the compiler to consider SimpleData literals to be
@@ -119,8 +122,8 @@ in normal form.
 At parse time, `mutez` and `address` literals are read in as ints and strings.
 
 ```k
-  syntax Mutez ::= Int
-  syntax Address ::= String
+  syntax MutezLiteral   ::= Int
+  syntax AddressLiteral ::= String
 ```
 
 `bytes` and `bool` literals must be converted from Michelson to K syntax.
@@ -512,7 +515,7 @@ instructions.
 
     ```k
     syntax BlockchainOperation ::=
-      "Create_contract" "{" Contract "}" OptionData Mutez Data Data
+      "Create_contract" "{" Contract "}" OptionData MutezLiteral Data Data
     ```
 
     - Contract (`contract`) The source code of the contract to originate; the
@@ -526,7 +529,7 @@ instructions.
 2.  Values produced by the `TRANSFER_TOKENS` instruction:
 
     ```k
-    syntax BlockchainOperation ::= "Transfer_tokens" Data Mutez Address Data
+    syntax BlockchainOperation ::= "Transfer_tokens" Data MutezLiteral AddressLiteral Data
     ```
 
     - Parameter (`T`) The parameter passed to the contract being invoked

--- a/tests/failing.cross
+++ b/tests/failing.cross
@@ -32,6 +32,11 @@ tests/unit/update_bigmapstringstring_04.tzt
 tests/unit/update_bigmapstringstring_05.tzt
 tests/unit/update_bigmapstringstring_06.tzt
 tests/unit/update_bigmapstringstring_07.tzt
+tests/unit/contract_06.tzt
+tests/unit/contract_07.tzt
+tests/unit/contract_08.tzt
+tests/unit/self_01.tzt
+tests/unit/self_02.tzt
 
 tests/macros/pair_00.tzt
 tests/macros/unpair_00.tzt

--- a/tests/proofs/multisig-spec.md
+++ b/tests/proofs/multisig-spec.md
@@ -107,7 +107,7 @@ The claims that we make have the following structure:
 ```
 claim <k> InitialSourceFragment => FinalSourceFragment </k>
       <stack> InitialStack => FinalStack </stack>
-      <paramtype> ContractParameterType </paramtype>
+      <paramtype> %default |-> ContractParameterType </paramtype>
       <myamount> AmountPassedToContract </myamount>
       requires Preconditions
       ensures Postconditions
@@ -124,7 +124,7 @@ that satisfies the preconditions, i.e., an instance of the following:
 ```
 <k> InitialSourceFragment </k>
 <stack> InitialStack  </stack>
-<paramtype> ContractParameterType </paramtype>
+<paramtype> %default |-> ContractParameterType </paramtype>
 <myamount> AmountPassedToContract </myamount>
 ```
 
@@ -134,7 +134,7 @@ which is an instance of:
 ```
 <k> FinalSourceFragment </k>
 <stack> FinalStack </stack>
-<paramtype> ContractParameterType </paramtype>
+<paramtype> %default |-> ContractParameterType </paramtype>
 <myamount> AmountPassedToContract </myamount>
 ```
 
@@ -288,7 +288,7 @@ The side conditions are defined as follows (and marked in the claim below):
          => [ pair ( list operation ) pair nat pair nat list key Pair uninterpreted ( Id , Unit ) Pair Count +Int 1 Pair Threshold KeyList:InternalList ] ; .Stack
     </stack>
     <myamount> #Mutez(Amount:Int) </myamount>
-    <paramtype> (or .AnnotationList unit .AnnotationList
+    <paramtype> %default |-> (or .AnnotationList unit .AnnotationList
                    pair .AnnotationList (pair .AnnotationList nat .AnnotationList
                               (or .AnnotationList (lambda .AnnotationList unit .AnnotationList (list .AnnotationList operation .AnnotationList ))
                                   pair .AnnotationList nat .AnnotationList

--- a/tests/proofs/return-spec.k
+++ b/tests/proofs/return-spec.k
@@ -25,14 +25,14 @@ module RETURN-SPEC
           } ;
           PAIR .AnnotationList
         } => .K </k>
-        <stack> [ (pair unit unit) Pair Unit Unit ] ; .Stack => [ (pair (list operation) unit) Pair [ Transfer_tokens Unit #Mutez(A) #Address("SourceAddr") ?_ ] ;; .InternalList Unit ] ; .Stack </stack>
+        <stack> [ (pair unit unit) Pair Unit Unit ] ; .Stack => [ (pair (list operation) unit) Pair [ Transfer_tokens Unit #Mutez(A) "SourceAddr" . %default ?_ ] ;; .InternalList Unit ] ; .Stack </stack>
         <paramtype> %default |-> unit .AnnotationList </paramtype>
         <storagetype> unit .AnnotationList </storagetype>
         <mybalance> #Mutez(0) </mybalance>
         <myamount> #Mutez(A) </myamount>
         <mynow> #Timestamp(0) </mynow>
         <myaddr> #Address("OwnAddr") </myaddr>
-        <knownaddrs> #Address("SourceAddr") |-> #Contract(#Address("SourceAddr"), unit .AnnotationList) </knownaddrs>
+        <knownaddrs> "SourceAddr" . %default |-> unit .AnnotationList </knownaddrs>
         <sourceaddr> #Address("SourceAddr") </sourceaddr>
         <senderaddr> #Address("SenderAddr") </senderaddr>
         <mychainid> #ChainId(_) </mychainid>
@@ -65,7 +65,7 @@ module RETURN-SPEC
         <myamount> #Mutez(0) </myamount>
         <mynow> #Timestamp(0) </mynow>
         <myaddr> #Address("OwnAddr") </myaddr>
-        <knownaddrs> #Address("SourceAddr") |-> #Contract(#Address("SourceAddr"), unit .AnnotationList) </knownaddrs>
+        <knownaddrs> "SourceAddr" . %default |-> unit .AnnotationList </knownaddrs>
         <sourceaddr> #Address("SourceAddr") </sourceaddr>
         <senderaddr> #Address("SenderAddr") </senderaddr>
         <mychainid> #ChainId(_) </mychainid>

--- a/tests/proofs/return-spec.k
+++ b/tests/proofs/return-spec.k
@@ -26,7 +26,7 @@ module RETURN-SPEC
           PAIR .AnnotationList
         } => .K </k>
         <stack> [ (pair unit unit) Pair Unit Unit ] ; .Stack => [ (pair (list operation) unit) Pair [ Transfer_tokens Unit #Mutez(A) #Address("SourceAddr") ?_ ] ;; .InternalList Unit ] ; .Stack </stack>
-        <paramtype> unit .AnnotationList </paramtype>
+        <paramtype> %default |-> unit .AnnotationList </paramtype>
         <storagetype> unit .AnnotationList </storagetype>
         <mybalance> #Mutez(0) </mybalance>
         <myamount> #Mutez(A) </myamount>
@@ -59,7 +59,7 @@ module RETURN-SPEC
           PAIR .AnnotationList
         } => .K </k>
         <stack> [ (pair unit unit) Pair Unit Unit ] ; .Stack => [ (pair (list operation) unit) Pair .InternalList Unit ] ; .Stack </stack>
-        <paramtype> unit .AnnotationList </paramtype>
+        <paramtype> %default |-> unit .AnnotationList </paramtype>
         <storagetype> unit .AnnotationList </storagetype>
         <mybalance> #Mutez(0) </mybalance>
         <myamount> #Mutez(0) </myamount>

--- a/tests/proofs/sum-to-n-spec.k
+++ b/tests/proofs/sum-to-n-spec.k
@@ -21,7 +21,7 @@ module SUM-TO-N-SPEC
                                            { PAIR .AnnotationList ; LEFT .AnnotationList nat .AnnotationList } } => .K </k>
         <stack> [(or (pair int int) int) Left (Pair A:Int B:Int)] ; .Stack
              => [int (B +Int ((A *Int (A +Int 1)) /Int 2))]       ; .Stack </stack>
-        <paramtype> nat .AnnotationList </paramtype>
+        <paramtype> %default |-> nat .AnnotationList </paramtype>
         <storagetype> nat .AnnotationList </storagetype>
       requires A >=Int 0 andBool B >=Int 0
 endmodule

--- a/tests/unit/contract_06.tzt
+++ b/tests/unit/contract_06.tzt
@@ -1,0 +1,4 @@
+code { CONTRACT %foo unit } ;
+input { Stack_elt address "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx" } ;
+output { Stack_elt (option (contract unit)) (Some "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx%foo") } ;
+other_contracts { Contract "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx" (or (unit %foo) (nat %bar)) }

--- a/tests/unit/contract_07.tzt
+++ b/tests/unit/contract_07.tzt
@@ -1,0 +1,4 @@
+code { CONTRACT %baz unit } ;
+input { Stack_elt address "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx" } ;
+output { Stack_elt (option (contract unit)) None } ;
+other_contracts { Contract "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx" (or (unit %foo) (nat %bar)) }

--- a/tests/unit/contract_08.tzt
+++ b/tests/unit/contract_08.tzt
@@ -1,0 +1,4 @@
+code { CONTRACT nat } ;
+input { Stack_elt address "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx" } ;
+output { Stack_elt (option (contract nat)) (Some "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx") } ;
+other_contracts { Contract "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx" (or (unit %foo) (nat %default)) }

--- a/tests/unit/self_01.tzt
+++ b/tests/unit/self_01.tzt
@@ -1,0 +1,5 @@
+code { SELF %default } ;
+input { } ;
+parameter int ;
+self "KT1BEqzn5Wx8uJrZNvuS9DVHmLvG9td3fDLi" ;
+output { Stack_elt (contract int) "KT1BEqzn5Wx8uJrZNvuS9DVHmLvG9td3fDLi" }

--- a/tests/unit/self_02.tzt
+++ b/tests/unit/self_02.tzt
@@ -1,0 +1,5 @@
+code { SELF %foo } ;
+input { } ;
+parameter (or (int %foo) (bool %bar)) ;
+self "KT1BEqzn5Wx8uJrZNvuS9DVHmLvG9td3fDLi" ;
+output { Stack_elt (contract int) "KT1BEqzn5Wx8uJrZNvuS9DVHmLvG9td3fDLi%foo" }


### PR DESCRIPTION
This PR allows most kinds of well-typed comparisons to be reduced into total comparison functions (without the need for `#if`) which seems to work better with K's Haskell backend.

This should be rebased on master and merged after #229