### PR TITLE
Split dexter spec into several modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -381,12 +381,21 @@ tests/%.prove: tests/% $(prove_kompiled)
 
 # Dexter proofs
 
+dexter_spec_modules = DEXTER-SPEC                 \
+                      DEXTER-SETMANAGER-SPEC      \
+                      DEXTER-SETBAKER-SPEC        \
+                      DEXTER-SETLQTADDRESS-SPEC   \
+                      DEXTER-UPDATETOKENPOOL-SPEC \
+                      DEXTER-DEFAULT-SPEC
+
 dexter_spec_file := tests/proofs/dexter/dexter-spec.md
 
-dexter-prove: KPROVE_MODULE  = DEXTER-VERIFICATION
-dexter-prove: KPROVE_OPTIONS = --spec-module DEXTER-SPEC
-dexter-prove: $(dexter_spec_file).dexter_prove
+dexter-prove: $(dexter_spec_modules:%=dexter-prove_%)
 
+dexter-prove_%:
+	$(MAKE) $(dexter_spec_file).dexter_prove \
+  KPROVE_MODULE=DEXTER-VERIFICATION        \
+  KPROVE_OPTIONS="--spec-module $*"
 
 tests/%.dexter_prove: tests/% $(dexter_kompiled)
 	$(TEST) prove --backend prove --backend-dir $(dexter_dir) $< $(KPROVE_MODULE) $(KPROVE_OPTIONS)

--- a/tests/proofs/dexter/dexter-spec.md
+++ b/tests/proofs/dexter/dexter-spec.md
@@ -17,7 +17,16 @@ module DEXTER-SPEC
         <mynow> #Timestamp(0) </mynow>
 ```
 
+```k
+endmodule
+```
+
 ## Set Manager
+
+```k
+module DEXTER-SETMANAGER-SPEC
+  imports DEXTER-VERIFICATION
+```
 
 The contract sets its manager to the provided manager address if the following conditions are satisfied:
 
@@ -49,7 +58,16 @@ If any of the conditions are not satisfied, the call fails.
       orBool IsUpdating
 ```
 
+```k
+endmodule
+```
+
 ## Set Baker
+
+```k
+module DEXTER-SETBAKER-SPEC
+  imports DEXTER-VERIFICATION
+```
 
 The contract sets its delegate to the value of `baker` (and optionally freezes the baker to that particular value) if the following conditions are satisfied:
 
@@ -87,7 +105,16 @@ If any of the conditions are not satisfied, the call fails.
       orBool Sender =/=K CurrentManager
 ```
 
+```k
+endmodule
+```
+
 ## Set LQT Address
+
+```k
+module DEXTER-SETLQTADDRESS-SPEC
+  imports DEXTER-VERIFICATION
+```
 
 The contract sets its liquidity pool adddress to the provided address if the following conditions are satisifed:
 
@@ -124,7 +151,16 @@ If any of the conditions are not satisfied, the call fails.
       orBool LQTAddress =/=K #Address("tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU")
 ```
 
+```k
+endmodule
+```
+
 ## Update Token Pool
+
+```k
+module DEXTER-UPDATETOKENPOOL-SPEC
+  imports DEXTER-VERIFICATION
+```
 
 The contract queries its underlying token contract for its own token balance if the following conditions are satisfied:
 
@@ -191,7 +227,16 @@ NOTE: The failure conditions are split into two claims with identical configurat
       andBool T =/=K #TokenContractType(IsFA2))
 ```
 
+```k
+endmodule
+```
+
 ## Default
+
+```k
+module DEXTER-DEFAULT-SPEC
+  imports DEXTER-VERIFICATION
+```
 
 Adds more money to the xtz reserves if the following conditions are satisifed:
 


### PR DESCRIPTION
This PR is to speed up our CI times. It splits the Dexter proofs at the Makefile level, but keeps them as a single CI target, for now. We can also make separate CI targets later if need be.