### PR TITLE
Add `token_to_xtz` spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -388,7 +388,14 @@ dexter_spec_modules = DEXTER-SPEC                       \
                       DEXTER-SETBAKER-SPEC              \
                       DEXTER-SETLQTADDRESS-SPEC         \
                       DEXTER-SETMANAGER-SPEC            \
+                      DEXTER-TOKENTOXTZ-FA12-NEG-1-SPEC \
+                      DEXTER-TOKENTOXTZ-FA12-NEG-2-SPEC \
+                      DEXTER-TOKENTOXTZ-FA12-NEG-3-SPEC \
+                      DEXTER-TOKENTOXTZ-FA12-NEG-4-SPEC \
                       DEXTER-TOKENTOXTZ-FA12-SPEC       \
+                      DEXTER-TOKENTOXTZ-FA2-NEG-1-SPEC  \
+                      DEXTER-TOKENTOXTZ-FA2-NEG-2-SPEC  \
+                      DEXTER-TOKENTOXTZ-FA2-NEG-3-SPEC  \
                       DEXTER-TOKENTOXTZ-FA2-SPEC        \
                       DEXTER-TOKENTOXTZ-SPEC            \
                       DEXTER-UPDATETOKENPOOL-SPEC       \

--- a/Makefile
+++ b/Makefile
@@ -383,13 +383,15 @@ tests/%.prove: tests/% $(prove_kompiled)
 
 dexter_spec_modules = DEXTER-SPEC                       \
                       DEXTER-ADDLIQUIDITY-NEGATIVE-SPEC \
+                      DEXTER-DEFAULT-SPEC               \
                       DEXTER-REMOVELIQUIDITY-SPEC       \
-                      DEXTER-SETMANAGER-SPEC            \
                       DEXTER-SETBAKER-SPEC              \
                       DEXTER-SETLQTADDRESS-SPEC         \
-					  DEXTER-TOKENTOXTZ-SPEC            \
+                      DEXTER-SETMANAGER-SPEC            \
+                      DEXTER-TOKENTOXTZ-FA12-SPEC       \
+                      DEXTER-TOKENTOXTZ-FA2-SPEC        \
+                      DEXTER-TOKENTOXTZ-SPEC            \
                       DEXTER-UPDATETOKENPOOL-SPEC       \
-                      DEXTER-DEFAULT-SPEC               \
 
 dexter_spec_file := tests/proofs/dexter/dexter-spec.md
 

--- a/Makefile
+++ b/Makefile
@@ -403,4 +403,4 @@ dexter-prove_%:
   KPROVE_OPTIONS="$(KPROVE_OPTIONS) --spec-module $*"
 
 tests/%.dexter_prove: tests/% $(dexter_kompiled)
-	$(TEST) prove --backend prove --backend-dir $(dexter_dir) $< $(KPROVE_MODULE) $(KPROVE_OPTIONS) --haskell-backend-command='kore-exec --smt-timeout 500'
+	$(TEST) prove --backend prove --backend-dir $(dexter_dir) $< $(KPROVE_MODULE) $(KPROVE_OPTIONS)

--- a/Makefile
+++ b/Makefile
@@ -403,4 +403,4 @@ dexter-prove_%:
   KPROVE_OPTIONS="$(KPROVE_OPTIONS) --spec-module $*"
 
 tests/%.dexter_prove: tests/% $(dexter_kompiled)
-	$(TEST) prove --backend prove --backend-dir $(dexter_dir) $< $(KPROVE_MODULE) $(KPROVE_OPTIONS)
+	$(TEST) prove --backend prove --backend-dir $(dexter_dir) $< $(KPROVE_MODULE) $(KPROVE_OPTIONS) --haskell-backend-command='kore-exec --smt-timeout 500'

--- a/Makefile
+++ b/Makefile
@@ -387,8 +387,9 @@ dexter_spec_modules = DEXTER-SPEC                       \
                       DEXTER-SETMANAGER-SPEC            \
                       DEXTER-SETBAKER-SPEC              \
                       DEXTER-SETLQTADDRESS-SPEC         \
+					  DEXTER-TOKENTOXTZ-SPEC            \
                       DEXTER-UPDATETOKENPOOL-SPEC       \
-                      DEXTER-DEFAULT-SPEC
+                      DEXTER-DEFAULT-SPEC               \
 
 dexter_spec_file := tests/proofs/dexter/dexter-spec.md
 

--- a/common.md
+++ b/common.md
@@ -96,8 +96,8 @@ We represent values of collection types (lists, sets, maps) as follows:
 The internal representation of mutez is bounded.
 
 ```k
-  syntax Int ::= "#MutezOverflowLimit" [function]
-  // --------------------------------------------
+  syntax Int ::= "#MutezOverflowLimit" [function, functional]
+  // --------------------------------------------------------
   rule #MutezOverflowLimit => 2 ^Int 63 // Signed 64 bit integers.
 
   syntax Bool ::= #IsLegalMutezValue(Int)   [function, functional]

--- a/michelson.md
+++ b/michelson.md
@@ -1713,10 +1713,17 @@ value is invalid.
 
   syntax FailedStack ::= #FailureFromMutezValue(Mutez, Int, Int) [function]
   // ----------------------------------------------------------------------
-  rule #FailureFromMutezValue(#Mutez(I), I1, I2)
-    => ( MutezOverflow I1 I2 ) requires I >=Int #MutezOverflowLimit
-  rule #FailureFromMutezValue(#Mutez(I), I1, I2)
-    => ( MutezUnderflow I1 I2 ) requires I <Int 0
+  rule #FailureFromMutezValue(#Mutez(I), I1, I2) => ( MutezOverflow I1 I2 )  requires I >=Int #MutezOverflowLimit
+  rule #FailureFromMutezValue(#Mutez(I), I1, I2) => ( MutezUnderflow I1 I2 ) requires I  <Int 0
+```
+
+```symbolic
+  rule #FailureFromMutezValue(#Mutez(I), I1, I2) => ( MutezOverflow I1 I2 )  requires I >=Int #MutezOverflowLimit [simplification]
+  rule #FailureFromMutezValue(#Mutez(I), I1, I2) => ( MutezUnderflow I1 I2 ) requires I  <Int 0                   [simplification]
+
+  rule #Ceil(#FailureFromMutezValue(#Mutez(I), I1, I2)) => #Bottom
+    requires notBool(I >=Int #MutezOverflowLimit orBool I  <Int 0)
+    [simplification]
 ```
 
 Other than the mutez validation step, these arithmetic rules are essentially

--- a/michelson.md
+++ b/michelson.md
@@ -2423,7 +2423,7 @@ When unfolding a symbolic container, we thus need to add a constraint forcing
 the item to be of the correct type.
 
 ```k
-    syntax KItem ::= #AssumeHasType(KItem, TypeName) 
+    syntax KItem ::= #AssumeHasType(KItem, TypeName)
 ```
 
 ```concrete

--- a/michelson.md
+++ b/michelson.md
@@ -1721,7 +1721,7 @@ value is invalid.
   rule #FailureFromMutezValue(#Mutez(I), I1, I2) => ( MutezOverflow I1 I2 )  requires I >=Int #MutezOverflowLimit [simplification]
   rule #FailureFromMutezValue(#Mutez(I), I1, I2) => ( MutezUnderflow I1 I2 ) requires I  <Int 0                   [simplification]
 
-  rule #Ceil(#FailureFromMutezValue(#Mutez(I), I1, I2)) => #Bottom
+  rule #Ceil(#FailureFromMutezValue(#Mutez(I), _I1, _I2)) => #Bottom
     requires notBool(I >=Int #MutezOverflowLimit orBool I  <Int 0)
     [simplification]
 ```

--- a/michelson.md
+++ b/michelson.md
@@ -1073,6 +1073,8 @@ The `#DoCompare` function requires additional lemmas for symbolic execution.
   rule X ==String X => true  [simplification]
   rule X  <String X => false [simplification]
 
+  rule #Ceil(#DoCompare(_:Int, _:Int)) => #Top [anywhere, simplification]
+
   rule #Ceil(#DoCompare(V1, V2)) => #Top
     requires (isBool(V1)      andBool isBool(V2))
       orBool (isInt(V1)       andBool isInt(V2))

--- a/tests/proofs/dexter/dexter-compiled.md
+++ b/tests/proofs/dexter/dexter-compiled.md
@@ -954,6 +954,7 @@ Since we work with specific code that contains a finite number of annotations, w
                                         CONS ;
                                         PAIR } } } }
                        // Left Right Right Right
+                       // token_to_xtz
                        { DUP ;
                          CDR ;
                          SWAP ;
@@ -2307,7 +2308,8 @@ Since we work with specific code that contains a finite number of annotations, w
                                         DIG 2 ;
                                         CONS ;
                                         PAIR } } } }
-                       { DUP ;
+                       { // token_to_xtz
+                         DUP ;
                          CDR ;
                          SWAP ;
                          CAR ;

--- a/tests/proofs/dexter/dexter-spec.md
+++ b/tests/proofs/dexter/dexter-spec.md
@@ -375,3 +375,46 @@ If any of the conditions are not satisfied, the call fails.
 ```k
 endmodule
 ```
+
+## Token To XTZ
+
+```k
+module DEXTER-TOKENTOXTZ-SPEC
+  imports DEXTER-VERIFICATION
+```
+
+A buyer sends tokens to the Dexter contract and receives a corresponding amount of xtz, if the following conditions are satisfied:
+
+1.  the token pool is _not_ currently updating (i.e. `storage.selfIsUpdatingTokenPool = false`)
+2.  the current block time must be less than the deadline
+3.  exactly 0 tez was transferred to this contract when it was invoked
+4.  the amount of tokens sold, when converted into xtz using the current exchange rate, is greater than `minXtzBought`
+5.  the amount of tokens sold, when converted into xtz using the current exchange rate, it is less than or equal to the xtz owned by the Dexter contract
+
+```k
+  claim <k> #runProof(IsFA2, TokenToXtz(To, TokensSold, #Mutez(MinXtzBought), #Timestamp(Deadline))) => . </k>
+        <stack> .Stack </stack>
+        <selfIsUpdatingTokenPool> false </selfIsUpdatingTokenPool>
+        <myamount> #Mutez(Amount) </myamount>
+        <tokenAddress> TokenAddress:Address </tokenAddress>
+        <xtzPool> #Mutez(XtzPool => XtzPool -Int #XtzBought(XtzPool, TokenPool, TokensSold)) </xtzPool>
+        <tokenPool> TokenPool => TokenPool +Int TokensSold </tokenPool>
+        <mynow> #Timestamp(CurrentTime) </mynow>
+        <senderaddr> Sender </senderaddr>
+        <myaddr> SelfAddress:Address </myaddr>
+        <nonce> #Nonce(N => N +Int 2) </nonce>
+        <tokenId> TokenID </tokenId>
+        <operations> _
+                  => [ Transfer_tokens #TokenTransferData(IsFA2, Sender, SelfAddress, TokenID, TokensSold) #Mutez(0)                                          TokenAddress  N        ]
+                  ;; [ Transfer_tokens Unit                                                                #Mutez(#XtzBought(XtzPool, TokenPool, TokensSold)) To           (N +Int 1)]
+                  ;; .InternalList
+        </operations>
+     requires Amount ==Int 0
+      andBool CurrentTime <Int Deadline
+      andBool #XtzBought(XtzPool, TokenPool, TokensSold) >Int  MinXtzBought
+      andBool #XtzBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
+```
+
+```k
+endmodule
+```

--- a/tests/proofs/dexter/dexter-spec.md
+++ b/tests/proofs/dexter/dexter-spec.md
@@ -419,7 +419,7 @@ A buyer sends tokens to the Dexter contract and receives a corresponding amount 
       andBool CurrentTime <Int Deadline
       andBool (TokenPool >Int 0 orBool TokensSold >Int 0)
       andBool (TokenPool >=Int 0) // Type Invariant
-      andBool #XtzBought(XtzPool, TokenPool, TokensSold) >Int  MinXtzBought
+      andBool #XtzBought(XtzPool, TokenPool, TokensSold) >=Int  MinXtzBought
       andBool #XtzBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
       andBool #IsLegalMutezValue(MinXtzBought)
       andBool #IsLegalMutezValue(#XtzBought(XtzPool, TokenPool, TokensSold))
@@ -489,7 +489,7 @@ module DEXTER-TOKENTOXTZ-FA12-NEG-3-SPEC
       andBool notBool CurrentTime <Int Deadline
       andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer,                             #TokenTransferType(IsFA2))
       andBool #EntrypointExists(KnownAddresses, To,           #token("%default", "FieldAnnotation"), #Type(unit))
-      andBool notBool( #XtzBought(XtzPool, TokenPool, TokensSold) >Int  MinXtzBought
+      andBool notBool( #XtzBought(XtzPool, TokenPool, TokensSold) >=Int  MinXtzBought
                andBool #IsLegalMutezValue(MinXtzBought)
                      )
 endmodule
@@ -513,7 +513,7 @@ module DEXTER-TOKENTOXTZ-FA12-NEG-4-SPEC
       andBool notBool CurrentTime <Int Deadline
       andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer,                             #TokenTransferType(IsFA2))
       andBool #EntrypointExists(KnownAddresses, To,           #token("%default", "FieldAnnotation"), #Type(unit))
-      andBool  #XtzBought(XtzPool, TokenPool, TokensSold) >Int  MinXtzBought
+      andBool  #XtzBought(XtzPool, TokenPool, TokensSold) >=Int  MinXtzBought
       andBool #IsLegalMutezValue(MinXtzBought)
       andBool notBool( #XtzBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
                andBool #IsLegalMutezValue(#XtzBought(XtzPool, TokenPool, TokensSold))
@@ -563,7 +563,7 @@ As before, a buyer sends tokens to the Dexter contract and receives a correspond
       andBool CurrentTime <Int Deadline
       andBool (TokenPool >Int 0 orBool TokensSold >Int 0)
       andBool (TokenPool >=Int 0)
-      andBool #XtzBought(XtzPool, TokenPool, TokensSold) >Int  MinXtzBought
+      andBool #XtzBought(XtzPool, TokenPool, TokensSold) >=Int  MinXtzBought
       andBool #XtzBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
       andBool #IsLegalMutezValue(MinXtzBought)
       andBool #IsLegalMutezValue(#XtzBought(XtzPool, TokenPool, TokensSold))
@@ -611,7 +611,7 @@ module DEXTER-TOKENTOXTZ-FA2-NEG-2-SPEC
       andBool CurrentTime <Int Deadline
       andBool (TokenPool >=Int 0)
       andBool notBool ( (TokenPool >Int 0 orBool TokensSold >Int 0)
-                andBool #XtzBought(XtzPool, TokenPool, TokensSold) >Int  MinXtzBought
+                andBool #XtzBought(XtzPool, TokenPool, TokensSold) >=Int  MinXtzBought
                 andBool #XtzBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
                       )
       andBool #IsLegalMutezValue(MinXtzBought)
@@ -642,7 +642,7 @@ module DEXTER-TOKENTOXTZ-FA2-NEG-3-SPEC
       andBool CurrentTime <Int Deadline
       andBool (TokenPool >=Int 0)
       andBool (TokenPool >Int 0 orBool TokensSold >Int 0)
-      andBool #XtzBought(XtzPool, TokenPool, TokensSold) >Int  MinXtzBought
+      andBool #XtzBought(XtzPool, TokenPool, TokensSold) >=Int  MinXtzBought
       andBool #XtzBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
       andBool notBool ( #IsLegalMutezValue(MinXtzBought)
                 andBool #IsLegalMutezValue(#XtzBought(XtzPool, TokenPool, TokensSold))

--- a/tests/proofs/dexter/dexter-spec.md
+++ b/tests/proofs/dexter/dexter-spec.md
@@ -403,6 +403,7 @@ A buyer sends tokens to the Dexter contract and receives a corresponding amount 
         <senderaddr> Sender </senderaddr>
         <myaddr> SelfAddress:Address </myaddr>
         <nonce> #Nonce(N => N +Int 2) </nonce>
+        <knownaddrs> KnownAddresses </knownaddrs>
         <tokenId> TokenID </tokenId>
         <operations> _
                   => [ Transfer_tokens #TokenTransferData(IsFA2, Sender, SelfAddress, TokenID, TokensSold) #Mutez(0)                                          TokenAddress  N        ]
@@ -413,6 +414,8 @@ A buyer sends tokens to the Dexter contract and receives a corresponding amount 
       andBool CurrentTime <Int Deadline
       andBool #XtzBought(XtzPool, TokenPool, TokensSold) >Int  MinXtzBought
       andBool #XtzBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
+      andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer,                             #TokenTransferType(IsFA2))
+      andBool #EntrypointExists(KnownAddresses, To,           #token("%default", "FieldAnnotation"), #Type(unit))
 ```
 
 ```k

--- a/tests/proofs/dexter/dexter-spec.md
+++ b/tests/proofs/dexter/dexter-spec.md
@@ -378,6 +378,8 @@ endmodule
 
 ## Token To XTZ
 
+### FA1.2
+
 ```k
 module DEXTER-TOKENTOXTZ-FA12-SPEC
   imports DEXTER-VERIFICATION
@@ -424,16 +426,14 @@ A buyer sends tokens to the Dexter contract and receives a corresponding amount 
       andBool #IsLegalMutezValue(XtzPool:Int -Int #XtzBought (XtzPool:Int, TokenPool:Int, TokensSold:Int))
       andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer,                             #TokenTransferType(IsFA2))
       andBool #EntrypointExists(KnownAddresses, To,           #token("%default", "FieldAnnotation"), #Type(unit))
+endmodule
 ```
 
-```k
-endmodule
+The following claims prove the negative case:
 
+```k
 module DEXTER-TOKENTOXTZ-FA12-NEG-1-SPEC
   imports DEXTER-VERIFICATION
-```
-
-```k
   claim <k> #runProof(IsFA2, TokenToXtz(_To, _TokensSold, #Mutez(_MinXtzBought), #Timestamp(Deadline))) => Aborted(?_, ?_, ?_, ?_) </k>
         <stack> .Stack => ?_ </stack>
         <selfIsUpdatingTokenPool> IsUpdating </selfIsUpdatingTokenPool>
@@ -446,16 +446,12 @@ module DEXTER-TOKENTOXTZ-FA12-NEG-1-SPEC
          orBool notBool Amount ==Int 0
          orBool notBool CurrentTime <Int Deadline
               )
+endmodule
 ```
 
 ```k
-endmodule
-
 module DEXTER-TOKENTOXTZ-FA12-NEG-2-SPEC
   imports DEXTER-VERIFICATION
-```
-
-```k
   claim <k> #runProof(IsFA2, TokenToXtz(To, TokensSold, #Mutez(MinXtzBought), #Timestamp(Deadline))) => Aborted(?_, ?_, ?_, ?_) </k>
         <stack> .Stack => ?_ </stack>
         <selfIsUpdatingTokenPool> IsUpdating </selfIsUpdatingTokenPool>
@@ -472,16 +468,12 @@ module DEXTER-TOKENTOXTZ-FA12-NEG-2-SPEC
       andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer,                             #TokenTransferType(IsFA2))
       andBool #EntrypointExists(KnownAddresses, To,           #token("%default", "FieldAnnotation"), #Type(unit))
       andBool notBool (TokenPool >Int 0 orBool TokensSold >Int 0)
+endmodule
 ```
 
 ```k
-endmodule
-
 module DEXTER-TOKENTOXTZ-FA12-NEG-3-SPEC
   imports DEXTER-VERIFICATION
-```
-
-```k
   claim <k> #runProof(IsFA2, TokenToXtz(To, TokensSold, #Mutez(MinXtzBought), #Timestamp(Deadline))) => Aborted(?_, ?_, ?_, ?_) </k>
         <stack> .Stack => ?_ </stack>
         <selfIsUpdatingTokenPool> IsUpdating </selfIsUpdatingTokenPool>
@@ -500,16 +492,12 @@ module DEXTER-TOKENTOXTZ-FA12-NEG-3-SPEC
       andBool notBool( #XtzBought(XtzPool, TokenPool, TokensSold) >Int  MinXtzBought
                andBool #IsLegalMutezValue(MinXtzBought)
                      )
+endmodule
 ```
 
 ```k
-endmodule
-
 module DEXTER-TOKENTOXTZ-FA12-NEG-4-SPEC
   imports DEXTER-VERIFICATION
-```
-
-```k
   claim <k> #runProof(IsFA2, TokenToXtz(To, TokensSold, #Mutez(MinXtzBought), #Timestamp(Deadline))) => Aborted(?_, ?_, ?_, ?_) </k>
         <stack> .Stack => ?_ </stack>
         <selfIsUpdatingTokenPool> IsUpdating </selfIsUpdatingTokenPool>
@@ -531,17 +519,17 @@ module DEXTER-TOKENTOXTZ-FA12-NEG-4-SPEC
                andBool #IsLegalMutezValue(#XtzBought(XtzPool, TokenPool, TokensSold))
                andBool #IsLegalMutezValue(XtzPool:Int -Int #XtzBought (XtzPool:Int, TokenPool:Int, TokensSold:Int))
                      )
-```
-```k
 endmodule
 ```
+
+### FA2
 
 ```k
 module DEXTER-TOKENTOXTZ-FA2-SPEC
   imports DEXTER-VERIFICATION
 ```
 
-A buyer sends tokens to the Dexter contract and receives a corresponding amount of xtz, if the following conditions are satisfied:
+As before, a buyer sends tokens to the Dexter contract and receives a corresponding amount of xtz, if the following conditions are satisfied:
 
 1.  the token pool is _not_ currently updating (i.e. `storage.selfIsUpdatingTokenPool = false`)
 2.  the current block time must be less than the deadline
@@ -582,16 +570,14 @@ A buyer sends tokens to the Dexter contract and receives a corresponding amount 
       andBool #IsLegalMutezValue(XtzPool:Int -Int #XtzBought (XtzPool:Int, TokenPool:Int, TokensSold:Int))
       andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer,                             #TokenTransferType(IsFA2))
       andBool #EntrypointExists(KnownAddresses, To,           #token("%default", "FieldAnnotation"), #Type(unit))
+endmodule
 ```
 
-```k
-endmodule
+The following cases prove the contract properly fails when these conditions aren't met.
 
+```k
 module DEXTER-TOKENTOXTZ-FA2-NEG-1-SPEC
   imports DEXTER-VERIFICATION
-```
-
-```k
   claim <k> #runProof(IsFA2, TokenToXtz(To, TokensSold, #Mutez(MinXtzBought), #Timestamp(Deadline))) =>  Aborted(?_, ?_, ?_, ?_) </k>
         <stack> .Stack => ?_ </stack>
         <selfIsUpdatingTokenPool> IsUpdating </selfIsUpdatingTokenPool>
@@ -603,20 +589,17 @@ module DEXTER-TOKENTOXTZ-FA2-NEG-1-SPEC
          orBool notBool Amount ==Int 0
          orBool notBool CurrentTime <Int Deadline
               )
-```
-```k
 endmodule
+```
 
+```k
 module DEXTER-TOKENTOXTZ-FA2-NEG-2-SPEC
   imports DEXTER-VERIFICATION
-```
-
-```k
   claim <k> #runProof(IsFA2, TokenToXtz(To, TokensSold, #Mutez(MinXtzBought), #Timestamp(Deadline))) =>  Aborted(?_, ?_, ?_, ?_) </k>
         <stack> .Stack => ?_ </stack>
         <selfIsUpdatingTokenPool> IsUpdating </selfIsUpdatingTokenPool>
         <myamount> #Mutez(Amount) </myamount>
-        <mynow> #Timestamp(CurrentTime) </mynow> 
+        <mynow> #Timestamp(CurrentTime) </mynow>
         <paramtype> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype>
         <tokenPool> TokenPool </tokenPool>
         <xtzPool> #Mutez(XtzPool) </xtzPool>
@@ -636,21 +619,17 @@ module DEXTER-TOKENTOXTZ-FA2-NEG-2-SPEC
                       )
       andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer,                             #TokenTransferType(IsFA2))
       andBool #EntrypointExists(KnownAddresses, To,           #token("%default", "FieldAnnotation"), #Type(unit))
+endmodule
 ```
 
 ```k
-endmodule
-
 module DEXTER-TOKENTOXTZ-FA2-NEG-3-SPEC
   imports DEXTER-VERIFICATION
-```
-
-```k
   claim <k> #runProof(IsFA2, TokenToXtz(To, TokensSold, #Mutez(MinXtzBought), #Timestamp(Deadline))) =>  Aborted(?_, ?_, ?_, ?_) </k>
         <stack> .Stack => ?_ </stack>
         <selfIsUpdatingTokenPool> IsUpdating </selfIsUpdatingTokenPool>
         <myamount> #Mutez(Amount) </myamount>
-        <mynow> #Timestamp(CurrentTime) </mynow> 
+        <mynow> #Timestamp(CurrentTime) </mynow>
         <paramtype> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype>
         <tokenPool> TokenPool </tokenPool>
         <xtzPool> #Mutez(XtzPool) </xtzPool>

--- a/tests/proofs/dexter/dexter-spec.md
+++ b/tests/proofs/dexter/dexter-spec.md
@@ -392,7 +392,7 @@ A buyer sends tokens to the Dexter contract and receives a corresponding amount 
 5.  the amount of tokens sold, when converted into xtz using the current exchange rate, it is less than or equal to the xtz owned by the Dexter contract
 
 ```k
-  claim <k> #runProof(IsFA2, TokenToXtz(To, TokensSold, #Mutez(MinXtzBought), #Timestamp(Deadline))) => . </k>
+  claim <k> #runProof(false, TokenToXtz(To, TokensSold, #Mutez(MinXtzBought), #Timestamp(Deadline))) => . </k>
         <stack> .Stack </stack>
         <selfIsUpdatingTokenPool> false </selfIsUpdatingTokenPool>
         <myamount> #Mutez(Amount) </myamount>
@@ -401,20 +401,26 @@ A buyer sends tokens to the Dexter contract and receives a corresponding amount 
         <tokenPool> TokenPool => TokenPool +Int TokensSold </tokenPool>
         <mynow> #Timestamp(CurrentTime) </mynow>
         <senderaddr> Sender </senderaddr>
+        <paramtype> #Type(#DexterVersionSpecificParamType(false)) </paramtype>
         <myaddr> SelfAddress:Address </myaddr>
         <nonce> #Nonce(N => N +Int 2) </nonce>
         <knownaddrs> KnownAddresses </knownaddrs>
         <tokenId> TokenID </tokenId>
         <operations> _
-                  => [ Transfer_tokens #TokenTransferData(IsFA2, Sender, SelfAddress, TokenID, TokensSold) #Mutez(0)                                          TokenAddress  N        ]
+                  => [ Transfer_tokens #TokenTransferData(false, Sender, SelfAddress, TokenID, TokensSold) #Mutez(0)                                          TokenAddress  N        ]
                   ;; [ Transfer_tokens Unit                                                                #Mutez(#XtzBought(XtzPool, TokenPool, TokensSold)) To           (N +Int 1)]
                   ;; .InternalList
         </operations>
      requires Amount ==Int 0
       andBool CurrentTime <Int Deadline
+      andBool (TokenPool >Int 0 orBool TokensSold >Int 0)
+      andBool (TokenPool >=Int 0)
       andBool #XtzBought(XtzPool, TokenPool, TokensSold) >Int  MinXtzBought
       andBool #XtzBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
-      andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer,                             #TokenTransferType(IsFA2))
+      andBool #IsLegalMutezValue(MinXtzBought)
+      andBool #IsLegalMutezValue(#XtzBought(XtzPool, TokenPool, TokensSold))
+      andBool #IsLegalMutezValue(XtzPool:Int -Int #XtzBought (XtzPool:Int, TokenPool:Int, TokensSold:Int))
+      andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer,                             #TokenTransferType(false))
       andBool #EntrypointExists(KnownAddresses, To,           #token("%default", "FieldAnnotation"), #Type(unit))
 ```
 

--- a/tests/proofs/dexter/dexter-spec.md
+++ b/tests/proofs/dexter/dexter-spec.md
@@ -427,6 +427,23 @@ A buyer sends tokens to the Dexter contract and receives a corresponding amount 
 ```
 
 ```k
+  claim <k> #runProof(IsFA2, TokenToXtz(To, TokensSold, #Mutez(MinXtzBought), #Timestamp(Deadline))) => Aborted(?_, ?_, ?_, ?_) </k>
+        <stack> .Stack => ?_ </stack>
+        <selfIsUpdatingTokenPool> IsUpdating </selfIsUpdatingTokenPool>
+        <mynow> #Timestamp(CurrentTime) </mynow>
+        <myamount> #Mutez(Amount) </myamount>
+        <tokenAddress> TokenAddress:Address </tokenAddress>
+        <xtzPool> #Mutez(XtzPool) </xtzPool>
+        <tokenPool> TokenPool </tokenPool>
+        <paramtype> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype>
+     requires notBool IsFA2
+      andBool ( IsUpdating
+         orBool notBool Amount ==Int 0
+         orBool notBool CurrentTime <Int Deadline
+              )
+```
+
+```k
 endmodule
 ```
 

--- a/tests/proofs/dexter/dexter-spec.md
+++ b/tests/proofs/dexter/dexter-spec.md
@@ -394,7 +394,7 @@ A buyer sends tokens to the Dexter contract and receives a corresponding amount 
 ```k
   claim <k> #runProof(IsFA2, TokenToXtz(To, TokensSold, #Mutez(MinXtzBought), #Timestamp(Deadline))) => . </k>
         <stack> .Stack </stack>
-        <selfIsUpdatingTokenPool> false </selfIsUpdatingTokenPool>
+        <selfIsUpdatingTokenPool> IsUpdating </selfIsUpdatingTokenPool>
         <myamount> #Mutez(Amount) </myamount>
         <tokenAddress> TokenAddress:Address </tokenAddress>
         <xtzPool> #Mutez(XtzPool => XtzPool -Int #XtzBought(XtzPool, TokenPool, TokensSold)) </xtzPool>
@@ -412,6 +412,7 @@ A buyer sends tokens to the Dexter contract and receives a corresponding amount 
                   ;; .InternalList
         </operations>
      requires notBool IsFA2
+      andBool notBool IsUpdating
       andBool Amount ==Int 0
       andBool CurrentTime <Int Deadline
       andBool (TokenPool >Int 0 orBool TokensSold >Int 0)
@@ -445,7 +446,7 @@ A buyer sends tokens to the Dexter contract and receives a corresponding amount 
 ```k
   claim <k> #runProof(IsFA2, TokenToXtz(To, TokensSold, #Mutez(MinXtzBought), #Timestamp(Deadline))) => . </k>
         <stack> .Stack </stack>
-        <selfIsUpdatingTokenPool> false </selfIsUpdatingTokenPool>
+        <selfIsUpdatingTokenPool> IsUpdating </selfIsUpdatingTokenPool>
         <myamount> #Mutez(Amount) </myamount>
         <tokenAddress> TokenAddress:Address </tokenAddress>
         <xtzPool> #Mutez(XtzPool => XtzPool -Int #XtzBought(XtzPool, TokenPool, TokensSold)) </xtzPool>
@@ -463,6 +464,7 @@ A buyer sends tokens to the Dexter contract and receives a corresponding amount 
                   ;; .InternalList
         </operations>
      requires IsFA2
+      andBool notBool IsUpdating
       andBool Amount ==Int 0
       andBool CurrentTime <Int Deadline
       andBool (TokenPool >Int 0 orBool TokensSold >Int 0)

--- a/tests/proofs/dexter/dexter-spec.md
+++ b/tests/proofs/dexter/dexter-spec.md
@@ -613,10 +613,10 @@ module DEXTER-TOKENTOXTZ-FA2-NEG-2-SPEC
       andBool notBool ( (TokenPool >Int 0 orBool TokensSold >Int 0)
                 andBool #XtzBought(XtzPool, TokenPool, TokensSold) >Int  MinXtzBought
                 andBool #XtzBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
-                andBool #IsLegalMutezValue(MinXtzBought)
-                andBool #IsLegalMutezValue(#XtzBought(XtzPool, TokenPool, TokensSold))
-                andBool #IsLegalMutezValue(XtzPool:Int -Int #XtzBought (XtzPool:Int, TokenPool:Int, TokensSold:Int))
                       )
+      andBool #IsLegalMutezValue(MinXtzBought)
+      andBool #IsLegalMutezValue(#XtzBought(XtzPool, TokenPool, TokensSold))
+      andBool #IsLegalMutezValue(XtzPool:Int -Int #XtzBought (XtzPool:Int, TokenPool:Int, TokensSold:Int))
       andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer,                             #TokenTransferType(IsFA2))
       andBool #EntrypointExists(KnownAddresses, To,           #token("%default", "FieldAnnotation"), #Type(unit))
 endmodule

--- a/tests/proofs/dexter/dexter-spec.md
+++ b/tests/proofs/dexter/dexter-spec.md
@@ -416,7 +416,7 @@ A buyer sends tokens to the Dexter contract and receives a corresponding amount 
       andBool Amount ==Int 0
       andBool CurrentTime <Int Deadline
       andBool (TokenPool >Int 0 orBool TokensSold >Int 0)
-      andBool (TokenPool >=Int 0)
+      andBool (TokenPool >=Int 0) // Type Invariant
       andBool #XtzBought(XtzPool, TokenPool, TokensSold) >Int  MinXtzBought
       andBool #XtzBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
       andBool #IsLegalMutezValue(MinXtzBought)
@@ -424,6 +424,21 @@ A buyer sends tokens to the Dexter contract and receives a corresponding amount 
       andBool #IsLegalMutezValue(XtzPool:Int -Int #XtzBought (XtzPool:Int, TokenPool:Int, TokensSold:Int))
       andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer,                             #TokenTransferType(IsFA2))
       andBool #EntrypointExists(KnownAddresses, To,           #token("%default", "FieldAnnotation"), #Type(unit))
+```
+
+```k
+  claim <k> #runProof(IsFA2, TokenToXtz(_To, _TokensSold, #Mutez(_MinXtzBought), #Timestamp(Deadline))) => Aborted(?_, ?_, ?_, ?_) </k>
+        <stack> .Stack => ?_ </stack>
+        <selfIsUpdatingTokenPool> IsUpdating </selfIsUpdatingTokenPool>
+        <mynow> #Timestamp(CurrentTime) </mynow>
+        <myamount> #Mutez(Amount) </myamount>
+        <tokenAddress> TokenAddress:Address </tokenAddress>
+        <paramtype> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype>
+     requires notBool IsFA2
+      andBool ( IsUpdating
+         orBool notBool Amount ==Int 0
+         orBool notBool CurrentTime <Int Deadline
+              )
 ```
 
 ```k
@@ -437,12 +452,58 @@ A buyer sends tokens to the Dexter contract and receives a corresponding amount 
         <tokenPool> TokenPool </tokenPool>
         <paramtype> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype>
      requires notBool IsFA2
-      andBool ( IsUpdating
-         orBool notBool Amount ==Int 0
-         orBool notBool CurrentTime <Int Deadline
-              )
+      andBool notBool IsUpdating
+      andBool notBool Amount ==Int 0
+      andBool notBool CurrentTime <Int Deadline
+      andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer,                             #TokenTransferType(IsFA2))
+      andBool #EntrypointExists(KnownAddresses, To,           #token("%default", "FieldAnnotation"), #Type(unit))
+      andBool notBool (TokenPool >Int 0 orBool TokensSold >Int 0)
 ```
 
+```k
+  claim <k> #runProof(IsFA2, TokenToXtz(To, TokensSold, #Mutez(MinXtzBought), #Timestamp(Deadline))) => Aborted(?_, ?_, ?_, ?_) </k>
+        <stack> .Stack => ?_ </stack>
+        <selfIsUpdatingTokenPool> IsUpdating </selfIsUpdatingTokenPool>
+        <mynow> #Timestamp(CurrentTime) </mynow>
+        <myamount> #Mutez(Amount) </myamount>
+        <tokenAddress> TokenAddress:Address </tokenAddress>
+        <xtzPool> #Mutez(XtzPool) </xtzPool>
+        <tokenPool> TokenPool </tokenPool>
+        <paramtype> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype>
+     requires notBool IsFA2
+      andBool notBool IsUpdating
+      andBool notBool Amount ==Int 0
+      andBool notBool CurrentTime <Int Deadline
+      andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer,                             #TokenTransferType(IsFA2))
+      andBool #EntrypointExists(KnownAddresses, To,           #token("%default", "FieldAnnotation"), #Type(unit))
+      andBool notBool( #XtzBought(XtzPool, TokenPool, TokensSold) >Int  MinXtzBought
+               andBool #IsLegalMutezValue(MinXtzBought)
+                     )
+```
+
+```k
+  claim <k> #runProof(IsFA2, TokenToXtz(To, TokensSold, #Mutez(MinXtzBought), #Timestamp(Deadline))) => Aborted(?_, ?_, ?_, ?_) </k>
+        <stack> .Stack => ?_ </stack>
+        <selfIsUpdatingTokenPool> IsUpdating </selfIsUpdatingTokenPool>
+        <mynow> #Timestamp(CurrentTime) </mynow>
+        <myamount> #Mutez(Amount) </myamount>
+        <tokenAddress> TokenAddress:Address </tokenAddress>
+        <xtzPool> #Mutez(XtzPool) </xtzPool>
+        <tokenPool> TokenPool </tokenPool>
+        <paramtype> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype>
+     requires notBool IsFA2
+      andBool notBool IsUpdating
+      andBool notBool Amount ==Int 0
+      andBool notBool CurrentTime <Int Deadline
+      andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer,                             #TokenTransferType(IsFA2))
+      andBool #EntrypointExists(KnownAddresses, To,           #token("%default", "FieldAnnotation"), #Type(unit))
+      andBool  #XtzBought(XtzPool, TokenPool, TokensSold) >Int  MinXtzBought
+      andBool #IsLegalMutezValue(MinXtzBought)
+      andBool notBool( #XtzBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
+               andBool #IsLegalMutezValue(#XtzBought(XtzPool, TokenPool, TokensSold))
+               andBool #IsLegalMutezValue(XtzPool:Int -Int #XtzBought (XtzPool:Int, TokenPool:Int, TokensSold:Int))
+                     )
+```
 ```k
 endmodule
 ```

--- a/tests/proofs/dexter/dexter-spec.md
+++ b/tests/proofs/dexter/dexter-spec.md
@@ -427,6 +427,13 @@ A buyer sends tokens to the Dexter contract and receives a corresponding amount 
 ```
 
 ```k
+endmodule
+
+module DEXTER-TOKENTOXTZ-FA12-NEG-1-SPEC
+  imports DEXTER-VERIFICATION
+```
+
+```k
   claim <k> #runProof(IsFA2, TokenToXtz(_To, _TokensSold, #Mutez(_MinXtzBought), #Timestamp(Deadline))) => Aborted(?_, ?_, ?_, ?_) </k>
         <stack> .Stack => ?_ </stack>
         <selfIsUpdatingTokenPool> IsUpdating </selfIsUpdatingTokenPool>
@@ -439,6 +446,13 @@ A buyer sends tokens to the Dexter contract and receives a corresponding amount 
          orBool notBool Amount ==Int 0
          orBool notBool CurrentTime <Int Deadline
               )
+```
+
+```k
+endmodule
+
+module DEXTER-TOKENTOXTZ-FA12-NEG-2-SPEC
+  imports DEXTER-VERIFICATION
 ```
 
 ```k
@@ -461,6 +475,13 @@ A buyer sends tokens to the Dexter contract and receives a corresponding amount 
 ```
 
 ```k
+endmodule
+
+module DEXTER-TOKENTOXTZ-FA12-NEG-3-SPEC
+  imports DEXTER-VERIFICATION
+```
+
+```k
   claim <k> #runProof(IsFA2, TokenToXtz(To, TokensSold, #Mutez(MinXtzBought), #Timestamp(Deadline))) => Aborted(?_, ?_, ?_, ?_) </k>
         <stack> .Stack => ?_ </stack>
         <selfIsUpdatingTokenPool> IsUpdating </selfIsUpdatingTokenPool>
@@ -479,6 +500,13 @@ A buyer sends tokens to the Dexter contract and receives a corresponding amount 
       andBool notBool( #XtzBought(XtzPool, TokenPool, TokensSold) >Int  MinXtzBought
                andBool #IsLegalMutezValue(MinXtzBought)
                      )
+```
+
+```k
+endmodule
+
+module DEXTER-TOKENTOXTZ-FA12-NEG-4-SPEC
+  imports DEXTER-VERIFICATION
 ```
 
 ```k
@@ -552,6 +580,95 @@ A buyer sends tokens to the Dexter contract and receives a corresponding amount 
       andBool #IsLegalMutezValue(MinXtzBought)
       andBool #IsLegalMutezValue(#XtzBought(XtzPool, TokenPool, TokensSold))
       andBool #IsLegalMutezValue(XtzPool:Int -Int #XtzBought (XtzPool:Int, TokenPool:Int, TokensSold:Int))
+      andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer,                             #TokenTransferType(IsFA2))
+      andBool #EntrypointExists(KnownAddresses, To,           #token("%default", "FieldAnnotation"), #Type(unit))
+```
+
+```k
+endmodule
+
+module DEXTER-TOKENTOXTZ-FA2-NEG-1-SPEC
+  imports DEXTER-VERIFICATION
+```
+
+```k
+  claim <k> #runProof(IsFA2, TokenToXtz(To, TokensSold, #Mutez(MinXtzBought), #Timestamp(Deadline))) =>  Aborted(?_, ?_, ?_, ?_) </k>
+        <stack> .Stack => ?_ </stack>
+        <selfIsUpdatingTokenPool> IsUpdating </selfIsUpdatingTokenPool>
+        <myamount> #Mutez(Amount) </myamount>
+        <mynow> #Timestamp(CurrentTime) </mynow>
+        <paramtype> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype>
+     requires IsFA2
+      andBool ( IsUpdating
+         orBool notBool Amount ==Int 0
+         orBool notBool CurrentTime <Int Deadline
+              )
+```
+```k
+endmodule
+
+module DEXTER-TOKENTOXTZ-FA2-NEG-2-SPEC
+  imports DEXTER-VERIFICATION
+```
+
+```k
+  claim <k> #runProof(IsFA2, TokenToXtz(To, TokensSold, #Mutez(MinXtzBought), #Timestamp(Deadline))) =>  Aborted(?_, ?_, ?_, ?_) </k>
+        <stack> .Stack => ?_ </stack>
+        <selfIsUpdatingTokenPool> IsUpdating </selfIsUpdatingTokenPool>
+        <myamount> #Mutez(Amount) </myamount>
+        <mynow> #Timestamp(CurrentTime) </mynow> 
+        <paramtype> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype>
+        <tokenPool> TokenPool </tokenPool>
+        <xtzPool> #Mutez(XtzPool) </xtzPool>
+        <tokenAddress> TokenAddress:Address </tokenAddress>
+        <knownaddrs> KnownAddresses </knownaddrs>
+     requires IsFA2
+      andBool notBool IsUpdating
+      andBool Amount ==Int 0
+      andBool CurrentTime <Int Deadline
+      andBool (TokenPool >=Int 0)
+      andBool notBool ( (TokenPool >Int 0 orBool TokensSold >Int 0)
+                andBool #XtzBought(XtzPool, TokenPool, TokensSold) >Int  MinXtzBought
+                andBool #XtzBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
+                andBool #IsLegalMutezValue(MinXtzBought)
+                andBool #IsLegalMutezValue(#XtzBought(XtzPool, TokenPool, TokensSold))
+                andBool #IsLegalMutezValue(XtzPool:Int -Int #XtzBought (XtzPool:Int, TokenPool:Int, TokensSold:Int))
+                      )
+      andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer,                             #TokenTransferType(IsFA2))
+      andBool #EntrypointExists(KnownAddresses, To,           #token("%default", "FieldAnnotation"), #Type(unit))
+```
+
+```k
+endmodule
+
+module DEXTER-TOKENTOXTZ-FA2-NEG-3-SPEC
+  imports DEXTER-VERIFICATION
+```
+
+```k
+  claim <k> #runProof(IsFA2, TokenToXtz(To, TokensSold, #Mutez(MinXtzBought), #Timestamp(Deadline))) =>  Aborted(?_, ?_, ?_, ?_) </k>
+        <stack> .Stack => ?_ </stack>
+        <selfIsUpdatingTokenPool> IsUpdating </selfIsUpdatingTokenPool>
+        <myamount> #Mutez(Amount) </myamount>
+        <mynow> #Timestamp(CurrentTime) </mynow> 
+        <paramtype> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype>
+        <tokenPool> TokenPool </tokenPool>
+        <xtzPool> #Mutez(XtzPool) </xtzPool>
+        <tokenAddress> TokenAddress:Address </tokenAddress>
+        <knownaddrs> KnownAddresses </knownaddrs>
+        <nonce> #Nonce(N => ?_) </nonce>
+     requires IsFA2
+      andBool notBool IsUpdating
+      andBool Amount ==Int 0
+      andBool CurrentTime <Int Deadline
+      andBool (TokenPool >=Int 0)
+      andBool (TokenPool >Int 0 orBool TokensSold >Int 0)
+      andBool #XtzBought(XtzPool, TokenPool, TokensSold) >Int  MinXtzBought
+      andBool #XtzBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
+      andBool notBool ( #IsLegalMutezValue(MinXtzBought)
+                andBool #IsLegalMutezValue(#XtzBought(XtzPool, TokenPool, TokensSold))
+                andBool #IsLegalMutezValue(XtzPool:Int -Int #XtzBought (XtzPool:Int, TokenPool:Int, TokensSold:Int))
+                      )
       andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer,                             #TokenTransferType(IsFA2))
       andBool #EntrypointExists(KnownAddresses, To,           #token("%default", "FieldAnnotation"), #Type(unit))
 ```

--- a/tests/proofs/dexter/dexter.md
+++ b/tests/proofs/dexter/dexter.md
@@ -658,21 +658,20 @@ If the contract execution fails, storage is not updated.
   rule #ceildivAux(X, Y) => X /Int Y          requires Y  =/=Int 0 andBool         X %Int Y ==Int 0
   rule #ceildivAux(X, Y) => X /Int Y +Int 1   requires Y  =/=Int 0 andBool notBool X %Int Y ==Int 0
 
-  syntax Int ::= #XtzBought   (Int, Int, Int)
-               | #TokensBought(Int, Int, Int)
+  syntax Int ::= #XtzBought   (Int, Int, Int) [function, functional, smtlib(xtzbought), no-evaluators]
  // -----------------------------------------
-  rule #XtzBought(XtzPool, TokenPool, TokensSold)
-    => (TokensSold *Int 997 *Int XtzPool) /Int (TokenPool *Int 1000 +Int (TokensSold *Int 997))
-    [macro]
+  rule (TokensSold *Int 997 *Int XtzPool) /Int (TokenPool *Int 1000 +Int (TokensSold *Int 997))
+    => #XtzBought(XtzPool, TokenPool, TokensSold)
+    [simplification]
 
-  syntax Int ::= #TokensBought(Int, Int, Int)
+  syntax Int ::= #TokensBought(Int, Int, Int) [function, functional, smtlib(tokensbought), no-evaluators]
  // ----------------------------------------
-  rule #TokensBought(XtzPool, TokenPool, XtzSold)
-    => (XtzSold *Int 997 *Int TokenPool) /Int (XtzPool *Int 1000 +Int (XtzSold *Int 997))
-    [macro]
+ // rule (XtzSold *Int 997 *Int TokenPool) /Int (XtzPool *Int 1000 +Int (XtzSold *Int 997))
+ //   => #TokensBought(XtzPool, TokenPool, XtzSold)
+ //   [simplification]
 
   syntax Bool ::= #EntrypointExists(Map, Address, FieldAnnotation, Type)
- // --------------------------------------------------------------------
+// --------------------------------------------------------------------
   rule #EntrypointExists(KnownAddresses, Addr, _FieldAnnot, EntrypointType)
     => Addr in_keys(KnownAddresses) andBool
        KnownAddresses[Addr] ==K #Contract(Addr, EntrypointType)

--- a/tests/proofs/dexter/dexter.md
+++ b/tests/proofs/dexter/dexter.md
@@ -377,21 +377,12 @@ Each entrypoint is given a unique abstract parameter type that we use to simplif
 
             ```
             ( [ Transfer_tokens ( txn.sender, self.address, tokensSold ) 0xtz self.tokenAddress %transfer ]
-              [ Transfer_tokens () $bought _to ],
-              { storage with xtzPool -= $bought ; tokenPool += tokensSold } )
+              [ Transfer_tokens () #XtzBought _to ],
+              { storage with xtzPool -= #XtzBought ; tokenPool += tokensSold } )
             ```
 
-            where `$bought` is the current total of xtz exchanged from `tokensSold` by the formula:
-
-            `(tokensSold * 997n * storage.xtzPool) / (storage.tokenPool * 1000n + (tokensSold * 997n))`
-
-        -   Summary: A buyer sends tokens to the Dexter contract and receives a corresponding amount of xtz, if the following conditions are satisfied:
-
-            1.  the token pool is _not_ currently updating (i.e. `storage.selfIsUpdatingTokenPool = false`)
-            2.  the current block time must be less than the deadline
-            3.  exactly 0 tez was transferred to this contract when it was invoked
-            4.  the amount of tokens sold, when converted into xtz using the current exchange rate, is greater than `minXtzBought`
-            5.  the amount of tokens sold, when converted into xtz using the current exchange rate, it is less than or equal to the xtz owned by the Dexter contract
+            where `#XtzBought` is the current total of xtz exchanged from `tokensSold` by the formula
+            defined by the macro below.
 
     11. `token_to_token`
 

--- a/tests/proofs/dexter/dexter.md
+++ b/tests/proofs/dexter/dexter.md
@@ -698,10 +698,14 @@ If all steps are completed, only the Dexter-specific storage is updated.
         ...
        </k>
        <myamount> #Mutez(Amount) </myamount>
+       <xtzPool> #Mutez(XtzPool) </xtzPool>
        <operations> OpList </operations>
+       <returncode> ReturnCode </returncode>
     ensures wellTypedParams(IsFA2, Params)
     andBool Amount >=Int 0
+    andBool #IsLegalMutezValue(XtzPool)
     andBool OpList ==K .InternalList
+    andBool ReturnCode ==Int 111
 ```
 
 ## Miscellaneous Lemmas

--- a/tests/proofs/dexter/dexter.md
+++ b/tests/proofs/dexter/dexter.md
@@ -704,6 +704,13 @@ If all steps are completed, only the Dexter-specific storage is updated.
     andBool OpList ==K .InternalList
 ```
 
+## Miscellaneous Lemmas
+
+```k
+    rule X *Int 1 => X [simplification]
+    rule X /Int 1 => X [simplification]
+```
+
 ## Epilogue
 
 We close out our module context now, which contains all of the information necessary to complete our proof.


### PR DESCRIPTION
Note: currently this PR only includes the positive case. The negative case is still pending.

All of the main assumptions should be present for the positive case to go through (assuming backend support). The main trick will be adding additional uninterpreted functions to prevent the backend from crashing with `DecidePredicateUnknown`.

Fixes: #248 