### PR TITLE
Miscellaneous updates to liquidity baking spec

### DIFF
--- a/kmich
+++ b/kmich
@@ -148,8 +148,9 @@ kompiled_dir=$(find $backend_dir -name '*-kompiled')
 [[ -d "$kompiled_dir" ]] || fatal "Could not find single *-kompiled directory in $backend_dir"
 
 ! $repl || \
-[[ "$backend" == prove ]] || \
+[[ "$backend" == prove  ]] || \
 [[ "$backend" == dexter ]] || \
+[[ "$backend" == lb     ]] || \
     fatal 'Option --repl only usable with `--backend prove` or `--backend dexter` !'
 
 # get the run file

--- a/lib/kast-lb.kscript
+++ b/lib/kast-lb.kscript
@@ -1,0 +1,11 @@
+alias kclaim      = claim    | kast -i kore -o pretty -d .build/defn/lb /dev/stdin
+alias kclaim-n x  = claim x  | kast -i kore -o pretty -d .build/defn/lb /dev/stdin
+alias kaxiom x    = axiom x  | kast -i kore -o pretty -d .build/defn/lb /dev/stdin
+alias ktry x      = try x    | kast -i kore -o pretty -d .build/defn/lb /dev/stdin
+alias ktryf x     = tryf x   | kast -i kore -o pretty -d .build/defn/lb /dev/stdin
+alias krule       = rule     | kast -i kore -o pretty -d .build/defn/lb /dev/stdin
+alias krule-n x   = rule x   | kast -i kore -o pretty -d .build/defn/lb /dev/stdin
+alias konfig      = config   | kprint .build/defn/lb/lb-kompiled /dev/stdin false
+alias konfig-n x  = config x | kprint .build/defn/lb/lb-kompiled /dev/stdin false
+alias kconfig     = konfig
+alias kconfig-n x = konfig-n x

--- a/tests/proofs/dexter/dexter-spec.md
+++ b/tests/proofs/dexter/dexter-spec.md
@@ -456,7 +456,7 @@ The contract queries its underlying token contract for its own token balance if 
         <operations> _ => [ Transfer_tokens Pair #UpdateTokenPoolTransferFrom(IsFA2, SelfAddress, TokenId) #Contract(SelfAddress . %updateTokenPoolInternal, #DexterVersionSpecificParamType(IsFA2)) #Mutez(0) #TokenBalanceEntrypoint(TokenAddress, IsFA2) O ] ;; .InternalList </operations>
         <nonce> #Nonce(O) => #Nonce(O +Int 1) </nonce>
     requires Amount ==Int 0
-     andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer, #TokenTransferType(IsFA2))
+     andBool #EntrypointExists(KnownAddresses, TokenAddress, #if IsFA2 #then %balance_of #else %getBalance #fi, #TokenBalanceEntrypointType(IsFA2))
      andBool #LocalEntrypointExists(LocalEntrypoints, %updateTokenPoolInternal, #Type(#DexterVersionSpecificParamType(IsFA2)))
      andBool #LocalEntrypointExists(LocalEntrypoints, %default,                 unit)
 ```
@@ -472,12 +472,15 @@ NOTE: The failure conditions are split into two claims with identical configurat
         <myamount> #Mutez(Amount) </myamount>
         <senderaddr> Sender </senderaddr>
         <sourceaddr> Source </sourceaddr>
-        <paramtype> _LocalEntrypoints </paramtype>
+        <paramtype> LocalEntrypoints </paramtype>
         <knownaddrs> KnownAddresses </knownaddrs>
-    requires Amount >Int 0
-     orBool (notBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer, #TokenTransferType(IsFA2)))
-     orBool IsUpdating
-     orBool Sender =/=K Source
+    requires ( Amount >Int 0
+      orBool (notBool #EntrypointExists(KnownAddresses, TokenAddress, #if IsFA2 #then %balance_of #else %getBalance #fi, #TokenBalanceEntrypointType(IsFA2)))
+      orBool IsUpdating
+      orBool Sender =/=K Source
+             )
+     andBool #LocalEntrypointExists(LocalEntrypoints, %updateTokenPoolInternal, #Type(#DexterVersionSpecificParamType(IsFA2)))
+     andBool #LocalEntrypointExists(LocalEntrypoints, %default,                 unit)
 ```
 
 ```k

--- a/tests/proofs/dexter/dexter-spec.md
+++ b/tests/proofs/dexter/dexter-spec.md
@@ -673,7 +673,7 @@ endmodule
 ### FA1.2
 
 ```k
-module DEXTER-TOKENTOXTZ-FA12-POSITIVE-SPEC // FIXME
+module DEXTER-TOKENTOXTZ-FA12-POSITIVE-SPEC
   imports DEXTER-VERIFICATION
 ```
 
@@ -825,7 +825,7 @@ endmodule
 ### FA2
 
 ```k
-module DEXTER-TOKENTOXTZ-FA2-POSITIVE-SPEC // FIXME
+module DEXTER-TOKENTOXTZ-FA2-POSITIVE-SPEC
   imports DEXTER-VERIFICATION
 ```
 
@@ -895,7 +895,7 @@ endmodule
 ```
 
 ```k
-module DEXTER-TOKENTOXTZ-FA2-NEGATIVE-2-SPEC // FIXME
+module DEXTER-TOKENTOXTZ-FA2-NEGATIVE-2-SPEC
   imports DEXTER-VERIFICATION
   claim <k> #runProof(IsFA2, TokenToXtz(To, TokensSold, #Mutez(MinXtzBought), #Timestamp(Deadline))) =>  Aborted(?_, ?_, ?_, ?_) </k>
         <stack> .Stack => ?_:FailedStack </stack>

--- a/tests/proofs/dexter/dexter-spec.md
+++ b/tests/proofs/dexter/dexter-spec.md
@@ -80,7 +80,7 @@ We have one case for when `#ceildiv` results in an upwards rounding, and one for
         <senderaddr> Sender </senderaddr>
         <nonce> #Nonce(Nonce => Nonce +Int 2) </nonce>
         <knownaddrs> KnownAddresses </knownaddrs>
-        <paramtype> %updateTokenPoolInternal |-> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype>
+        <paramtype> LocalEntrypoints </paramtype>
         <operations> _
                   => [ Transfer_tokens #TokenTransferData(IsFA2, Sender, SelfAddress, TokenId, #ceildiv(Amount *Int TokenAmount, XtzAmount)) #Mutez(0) TokenAddress . %transfer Nonce ] ;;
                      [ Transfer_tokens Pair ((Amount *Int OldLqt) /Int XtzAmount) Owner #Mutez(0) LqtAddress . %mintOrBurn (Nonce +Int 1) ] ;;
@@ -95,6 +95,8 @@ We have one case for when `#ceildiv` results in an upwards rounding, and one for
 
      andBool #EntrypointExists(KnownAddresses, TokenAddress,   %transfer, #TokenTransferType(IsFA2))
      andBool #EntrypointExists(KnownAddresses,   LqtAddress, %mintOrBurn, pair int %quantity .AnnotationList address %target .AnnotationList)
+     andBool #LocalEntrypointExists(LocalEntrypoints, %updateTokenPoolInternal, #Type(#DexterVersionSpecificParamType(IsFA2)))
+     andBool #LocalEntrypointExists(LocalEntrypoints, %default,                 unit)
 ```
 
 ```k
@@ -113,7 +115,7 @@ We have one case for when `#ceildiv` results in an upwards rounding, and one for
         <senderaddr> Sender </senderaddr>
         <nonce> #Nonce(Nonce => Nonce +Int 2) </nonce>
         <knownaddrs> KnownAddresses </knownaddrs>
-        <paramtype> %updateTokenPoolInternal |-> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype>
+        <paramtype> LocalEntrypoints </paramtype>
         <operations> _
                   => [ Transfer_tokens #TokenTransferData(IsFA2, Sender, SelfAddress, TokenId, #ceildiv(Amount *Int TokenAmount, XtzAmount)) #Mutez(0) TokenAddress . %transfer Nonce ] ;;
                      [ Transfer_tokens Pair ((Amount *Int OldLqt) /Int XtzAmount) Owner #Mutez(0) LqtAddress . %mintOrBurn (Nonce +Int 1) ] ;;
@@ -129,6 +131,8 @@ We have one case for when `#ceildiv` results in an upwards rounding, and one for
 
      andBool #EntrypointExists(KnownAddresses, TokenAddress,   %transfer, #TokenTransferType(IsFA2))
      andBool #EntrypointExists(KnownAddresses,   LqtAddress, %mintOrBurn, pair int %quantity .AnnotationList address %target .AnnotationList)
+     andBool #LocalEntrypointExists(LocalEntrypoints, %updateTokenPoolInternal, #Type(#DexterVersionSpecificParamType(IsFA2)))
+     andBool #LocalEntrypointExists(LocalEntrypoints, %default,                 unit)
 ```
 
 ```k
@@ -223,7 +227,7 @@ module DEXTER-REMOVELIQUIDITY-POSITIVE-SPEC
         <senderaddr> Sender </senderaddr>
         <nonce> #Nonce(Nonce => Nonce +Int 3) </nonce>
         <knownaddrs> KnownAddresses </knownaddrs>
-        <paramtype> %updateTokenPoolInternal |-> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype> // 1027
+        <paramtype> LocalEntrypoints </paramtype> // 1027
         <operations> _
                   => [ Transfer_tokens (Pair (0 -Int LqtBurned) Sender) #Mutez(0) LqtAddress . %mintOrBurn Nonce ] ;;
                      [ Transfer_tokens #TokenTransferData(IsFA2, SelfAddress, To, TokenId,  (LqtBurned *Int TokenAmount) /Int OldLqt) #Mutez(0) TokenAddress . %transfer (Nonce +Int 1) ] ;;
@@ -238,6 +242,8 @@ module DEXTER-REMOVELIQUIDITY-POSITIVE-SPEC
      andBool #EntrypointExists(KnownAddresses, TokenAddress,   %transfer, #TokenTransferType(IsFA2))
      andBool #EntrypointExists(KnownAddresses,   LqtAddress, %mintOrBurn, pair int %quantity .AnnotationList address %target .AnnotationList)
      andBool #EntrypointExists(KnownAddresses,           To,    %default, unit)
+     andBool #LocalEntrypointExists(LocalEntrypoints, %updateTokenPoolInternal, #Type(#DexterVersionSpecificParamType(IsFA2)))
+     andBool #LocalEntrypointExists(LocalEntrypoints, %default,                 unit)
 
      andBool #IsLegalMutezValue(XtzAmount)
      andBool #IsLegalMutezValue((LqtBurned *Int XtzAmount) /Int OldLqt)
@@ -445,12 +451,14 @@ The contract queries its underlying token contract for its own token balance if 
         <myamount> #Mutez(Amount) </myamount>
         <senderaddr> Sender </senderaddr>
         <sourceaddr> Sender </sourceaddr>
-        <paramtype> %updateTokenPoolInternal |-> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype>
+        <paramtype> LocalEntrypoints </paramtype>
         <knownaddrs> KnownAddresses </knownaddrs>
         <operations> _ => [ Transfer_tokens Pair #UpdateTokenPoolTransferFrom(IsFA2, SelfAddress, TokenId) #Contract(SelfAddress . %updateTokenPoolInternal, #DexterVersionSpecificParamType(IsFA2)) #Mutez(0) #TokenBalanceEntrypoint(TokenAddress, IsFA2) O ] ;; .InternalList </operations>
         <nonce> #Nonce(O) => #Nonce(O +Int 1) </nonce>
     requires Amount ==Int 0
      andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer, #TokenTransferType(IsFA2))
+     andBool #LocalEntrypointExists(LocalEntrypoints, %updateTokenPoolInternal, #Type(#DexterVersionSpecificParamType(IsFA2)))
+     andBool #LocalEntrypointExists(LocalEntrypoints, %default,                 unit)
 ```
 
 If any of the conditions are not satisfied, the call fails.
@@ -464,7 +472,7 @@ NOTE: The failure conditions are split into two claims with identical configurat
         <myamount> #Mutez(Amount) </myamount>
         <senderaddr> Sender </senderaddr>
         <sourceaddr> Source </sourceaddr>
-        <paramtype> %updateTokenPoolInternal |-> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype>
+        <paramtype> _LocalEntrypoints </paramtype>
         <knownaddrs> KnownAddresses </knownaddrs>
     requires Amount >Int 0
      orBool (notBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer, #TokenTransferType(IsFA2)))
@@ -662,7 +670,7 @@ endmodule
 ### FA1.2
 
 ```k
-module DEXTER-TOKENTOXTZ-FA12-POSITIVE-SPEC
+module DEXTER-TOKENTOXTZ-FA12-POSITIVE-SPEC // FIXME
   imports DEXTER-VERIFICATION
 ```
 
@@ -680,18 +688,18 @@ A buyer sends tokens to the Dexter contract and receives a corresponding amount 
         <selfIsUpdatingTokenPool> IsUpdating </selfIsUpdatingTokenPool>
         <myamount> #Mutez(Amount) </myamount>
         <tokenAddress> TokenAddress:Address </tokenAddress>
-        <xtzPool> #Mutez(XtzPool => XtzPool -Int #XtzBought(XtzPool, TokenPool, TokensSold)) </xtzPool>
+        <xtzPool> #Mutez(XtzPool => XtzPool -Int #CurrencyBought(XtzPool, TokenPool, TokensSold)) </xtzPool>
         <tokenPool> TokenPool => TokenPool +Int TokensSold </tokenPool>
         <mynow> #Timestamp(CurrentTime) </mynow>
         <senderaddr> Sender </senderaddr>
-        <paramtype> %updateTokenPoolInternal |-> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype>
+        <paramtype> LocalEntrypoints </paramtype>
         <myaddr> SelfAddress:Address </myaddr>
         <nonce> #Nonce(N => N +Int 2) </nonce>
         <knownaddrs> KnownAddresses </knownaddrs>
         <tokenId> TokenID </tokenId>
         <operations> _
-                  => [ Transfer_tokens #TokenTransferData(IsFA2, Sender, SelfAddress, TokenID, TokensSold) #Mutez(0)                                          TokenAddress . %transfer N        ]
-                  ;; [ Transfer_tokens Unit                                                                #Mutez(#XtzBought(XtzPool, TokenPool, TokensSold)) To           . %default (N +Int 1)]
+                  => [ Transfer_tokens #TokenTransferData(IsFA2, Sender, SelfAddress, TokenID, TokensSold) #Mutez(0)                                               TokenAddress . %transfer N        ]
+                  ;; [ Transfer_tokens Unit                                                                #Mutez(#CurrencyBought(XtzPool, TokenPool, TokensSold)) To           . %default (N +Int 1)]
                   ;; .InternalList
         </operations>
      requires notBool IsFA2
@@ -700,13 +708,15 @@ A buyer sends tokens to the Dexter contract and receives a corresponding amount 
       andBool CurrentTime <Int Deadline
       andBool (TokenPool >Int 0 orBool TokensSold >Int 0)
       andBool (TokenPool >=Int 0) // Type Invariant
-      andBool #XtzBought(XtzPool, TokenPool, TokensSold) >=Int  MinXtzBought
-      andBool #XtzBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
+      andBool #CurrencyBought(XtzPool, TokenPool, TokensSold) >=Int MinXtzBought
+      andBool #CurrencyBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
       andBool #IsLegalMutezValue(MinXtzBought)
-      andBool #IsLegalMutezValue(#XtzBought(XtzPool, TokenPool, TokensSold))
-      andBool #IsLegalMutezValue(XtzPool:Int -Int #XtzBought (XtzPool:Int, TokenPool:Int, TokensSold:Int))
+      andBool #IsLegalMutezValue(#CurrencyBought(XtzPool, TokenPool, TokensSold))
+      andBool #IsLegalMutezValue(XtzPool:Int -Int #CurrencyBought (XtzPool:Int, TokenPool:Int, TokensSold:Int))
       andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer,                             #TokenTransferType(IsFA2))
       andBool #EntrypointExists(KnownAddresses, To,           #token("%default", "FieldAnnotation"), #Type(unit))
+      andBool #LocalEntrypointExists(LocalEntrypoints, %updateTokenPoolInternal, #Type(#DexterVersionSpecificParamType(IsFA2)))
+      andBool #LocalEntrypointExists(LocalEntrypoints, %default,                 unit)
 endmodule
 ```
 
@@ -721,7 +731,7 @@ module DEXTER-TOKENTOXTZ-FA12-NEGATIVE-1-SPEC
         <mynow> #Timestamp(CurrentTime) </mynow>
         <myamount> #Mutez(Amount) </myamount>
         <tokenAddress> _TokenAddress:Address </tokenAddress>
-        <paramtype> %updateTokenPoolInternal |-> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype>
+        <paramtype> _LocalEntrypoints </paramtype>
      requires notBool IsFA2
       andBool ( IsUpdating
          orBool notBool Amount ==Int 0
@@ -741,13 +751,15 @@ module DEXTER-TOKENTOXTZ-FA12-NEGATIVE-2-SPEC
         <tokenAddress> TokenAddress:Address </tokenAddress>
         <xtzPool> #Mutez(_XtzPool) </xtzPool>
         <tokenPool> TokenPool </tokenPool>
-        <paramtype> %updateTokenPoolInternal |-> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype>
+        <paramtype> LocalEntrypoints </paramtype>
      requires notBool IsFA2
       andBool notBool IsUpdating
       andBool notBool Amount ==Int 0
       andBool notBool CurrentTime <Int Deadline
       andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer,                             #TokenTransferType(IsFA2))
       andBool #EntrypointExists(KnownAddresses, To,           #token("%default", "FieldAnnotation"), #Type(unit))
+      andBool #LocalEntrypointExists(LocalEntrypoints, %updateTokenPoolInternal, #Type(#DexterVersionSpecificParamType(IsFA2)))
+      andBool #LocalEntrypointExists(LocalEntrypoints, %default,                 unit)
       andBool notBool (TokenPool >Int 0 orBool TokensSold >Int 0)
 endmodule
 ```
@@ -763,14 +775,16 @@ module DEXTER-TOKENTOXTZ-FA12-NEGATIVE-3-SPEC
         <tokenAddress> TokenAddress:Address </tokenAddress>
         <xtzPool> #Mutez(XtzPool) </xtzPool>
         <tokenPool> TokenPool </tokenPool>
-        <paramtype> %updateTokenPoolInternal |-> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype>
+        <paramtype> LocalEntrypoints </paramtype>
      requires notBool IsFA2
       andBool notBool IsUpdating
       andBool notBool Amount ==Int 0
       andBool notBool CurrentTime <Int Deadline
       andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer,                             #TokenTransferType(IsFA2))
       andBool #EntrypointExists(KnownAddresses, To,           #token("%default", "FieldAnnotation"), #Type(unit))
-      andBool notBool( #XtzBought(XtzPool, TokenPool, TokensSold) >=Int  MinXtzBought
+      andBool #LocalEntrypointExists(LocalEntrypoints, %updateTokenPoolInternal, #Type(#DexterVersionSpecificParamType(IsFA2)))
+      andBool #LocalEntrypointExists(LocalEntrypoints, %default,                 unit)
+      andBool notBool( #CurrencyBought(XtzPool, TokenPool, TokensSold) >=Int  MinXtzBought
                andBool #IsLegalMutezValue(MinXtzBought)
                      )
 endmodule
@@ -787,18 +801,20 @@ module DEXTER-TOKENTOXTZ-FA12-NEGATIVE-4-SPEC
         <tokenAddress> TokenAddress:Address </tokenAddress>
         <xtzPool> #Mutez(XtzPool) </xtzPool>
         <tokenPool> TokenPool </tokenPool>
-        <paramtype> %updateTokenPoolInternal |-> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype>
+        <paramtype> LocalEntrypoints </paramtype>
      requires notBool IsFA2
       andBool notBool IsUpdating
       andBool notBool Amount ==Int 0
       andBool notBool CurrentTime <Int Deadline
       andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer,                             #TokenTransferType(IsFA2))
       andBool #EntrypointExists(KnownAddresses, To,           #token("%default", "FieldAnnotation"), #Type(unit))
-      andBool  #XtzBought(XtzPool, TokenPool, TokensSold) >=Int  MinXtzBought
+      andBool #LocalEntrypointExists(LocalEntrypoints, %updateTokenPoolInternal, #Type(#DexterVersionSpecificParamType(IsFA2)))
+      andBool #LocalEntrypointExists(LocalEntrypoints, %default,                 unit)
+      andBool  #CurrencyBought(XtzPool, TokenPool, TokensSold) >=Int  MinXtzBought
       andBool #IsLegalMutezValue(MinXtzBought)
-      andBool notBool( #XtzBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
-               andBool #IsLegalMutezValue(#XtzBought(XtzPool, TokenPool, TokensSold))
-               andBool #IsLegalMutezValue(XtzPool:Int -Int #XtzBought (XtzPool:Int, TokenPool:Int, TokensSold:Int))
+      andBool notBool( #CurrencyBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
+               andBool #IsLegalMutezValue(#CurrencyBought(XtzPool, TokenPool, TokensSold))
+               andBool #IsLegalMutezValue(XtzPool:Int -Int #CurrencyBought (XtzPool:Int, TokenPool:Int, TokensSold:Int))
                      )
 endmodule
 ```
@@ -806,7 +822,7 @@ endmodule
 ### FA2
 
 ```k
-module DEXTER-TOKENTOXTZ-FA2-POSITIVE-SPEC
+module DEXTER-TOKENTOXTZ-FA2-POSITIVE-SPEC // FIXME
   imports DEXTER-VERIFICATION
 ```
 
@@ -824,18 +840,18 @@ As before, a buyer sends tokens to the Dexter contract and receives a correspond
         <selfIsUpdatingTokenPool> IsUpdating </selfIsUpdatingTokenPool>
         <myamount> #Mutez(Amount) </myamount>
         <tokenAddress> TokenAddress:Address </tokenAddress>
-        <xtzPool> #Mutez(XtzPool => XtzPool -Int #XtzBought(XtzPool, TokenPool, TokensSold)) </xtzPool>
+        <xtzPool> #Mutez(XtzPool => XtzPool -Int #CurrencyBought(XtzPool, TokenPool, TokensSold)) </xtzPool>
         <tokenPool> TokenPool => TokenPool +Int TokensSold </tokenPool>
         <mynow> #Timestamp(CurrentTime) </mynow>
         <senderaddr> Sender </senderaddr>
-        <paramtype> %updateTokenPoolInternal |-> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype>
+        <paramtype> LocalEntrypoints </paramtype>
         <myaddr> SelfAddress:Address </myaddr>
         <nonce> #Nonce(N => N +Int 2) </nonce>
         <knownaddrs> KnownAddresses </knownaddrs>
         <tokenId> TokenID </tokenId>
         <operations> _
-                  => [ Transfer_tokens #TokenTransferData(IsFA2, Sender, SelfAddress, TokenID, TokensSold) #Mutez(0)                                          TokenAddress . %transfer N        ]
-                  ;; [ Transfer_tokens Unit                                                                #Mutez(#XtzBought(XtzPool, TokenPool, TokensSold)) To           . %default (N +Int 1)]
+                  => [ Transfer_tokens #TokenTransferData(IsFA2, Sender, SelfAddress, TokenID, TokensSold) #Mutez(0)                                               TokenAddress . %transfer N        ]
+                  ;; [ Transfer_tokens Unit                                                                #Mutez(#CurrencyBought(XtzPool, TokenPool, TokensSold)) To           . %default (N +Int 1)]
                   ;; .InternalList
         </operations>
      requires IsFA2
@@ -844,13 +860,15 @@ As before, a buyer sends tokens to the Dexter contract and receives a correspond
       andBool CurrentTime <Int Deadline
       andBool (TokenPool >Int 0 orBool TokensSold >Int 0)
       andBool (TokenPool >=Int 0)
-      andBool #XtzBought(XtzPool, TokenPool, TokensSold) >=Int  MinXtzBought
-      andBool #XtzBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
+      andBool #CurrencyBought(XtzPool, TokenPool, TokensSold) >=Int  MinXtzBought
+      andBool #CurrencyBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
       andBool #IsLegalMutezValue(MinXtzBought)
-      andBool #IsLegalMutezValue(#XtzBought(XtzPool, TokenPool, TokensSold))
-      andBool #IsLegalMutezValue(XtzPool:Int -Int #XtzBought (XtzPool:Int, TokenPool:Int, TokensSold:Int))
+      andBool #IsLegalMutezValue(#CurrencyBought(XtzPool, TokenPool, TokensSold))
+      andBool #IsLegalMutezValue(XtzPool:Int -Int #CurrencyBought (XtzPool:Int, TokenPool:Int, TokensSold:Int))
       andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer,                             #TokenTransferType(IsFA2))
       andBool #EntrypointExists(KnownAddresses, To,           #token("%default", "FieldAnnotation"), #Type(unit))
+      andBool #LocalEntrypointExists(LocalEntrypoints, %updateTokenPoolInternal, #Type(#DexterVersionSpecificParamType(IsFA2)))
+      andBool #LocalEntrypointExists(LocalEntrypoints, %default,                 unit)
 endmodule
 ```
 
@@ -864,7 +882,7 @@ module DEXTER-TOKENTOXTZ-FA2-NEGATIVE-1-SPEC
         <selfIsUpdatingTokenPool> IsUpdating </selfIsUpdatingTokenPool>
         <myamount> #Mutez(Amount) </myamount>
         <mynow> #Timestamp(CurrentTime) </mynow>
-        <paramtype> %updateTokenPoolInternal |-> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype>
+        <paramtype> _LocalEntrypoints </paramtype>
      requires IsFA2
       andBool ( IsUpdating
          orBool notBool Amount ==Int 0
@@ -874,14 +892,14 @@ endmodule
 ```
 
 ```k
-module DEXTER-TOKENTOXTZ-FA2-NEGATIVE-2-SPEC
+module DEXTER-TOKENTOXTZ-FA2-NEGATIVE-2-SPEC // FIXME
   imports DEXTER-VERIFICATION
   claim <k> #runProof(IsFA2, TokenToXtz(To, TokensSold, #Mutez(MinXtzBought), #Timestamp(Deadline))) =>  Aborted(?_, ?_, ?_, ?_) </k>
         <stack> .Stack => ?_:FailedStack </stack>
         <selfIsUpdatingTokenPool> IsUpdating </selfIsUpdatingTokenPool>
         <myamount> #Mutez(Amount) </myamount>
         <mynow> #Timestamp(CurrentTime) </mynow>
-        <paramtype> %updateTokenPoolInternal |-> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype>
+        <paramtype> LocalEntrypoints </paramtype>
         <tokenPool> TokenPool </tokenPool>
         <xtzPool> #Mutez(XtzPool) </xtzPool>
         <tokenAddress> TokenAddress:Address </tokenAddress>
@@ -892,14 +910,16 @@ module DEXTER-TOKENTOXTZ-FA2-NEGATIVE-2-SPEC
       andBool CurrentTime <Int Deadline
       andBool (TokenPool >=Int 0)
       andBool notBool ( (TokenPool >Int 0 orBool TokensSold >Int 0)
-                andBool #XtzBought(XtzPool, TokenPool, TokensSold) >=Int  MinXtzBought
-                andBool #XtzBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
+                andBool #CurrencyBought(XtzPool, TokenPool, TokensSold) >=Int  MinXtzBought
+                andBool #CurrencyBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
                       )
       andBool #IsLegalMutezValue(MinXtzBought)
-      andBool #IsLegalMutezValue(#XtzBought(XtzPool, TokenPool, TokensSold))
-      andBool #IsLegalMutezValue(XtzPool:Int -Int #XtzBought (XtzPool:Int, TokenPool:Int, TokensSold:Int))
+      andBool #IsLegalMutezValue(#CurrencyBought(XtzPool, TokenPool, TokensSold))
+      andBool #IsLegalMutezValue(XtzPool:Int -Int #CurrencyBought (XtzPool:Int, TokenPool:Int, TokensSold:Int))
       andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer,                             #TokenTransferType(IsFA2))
       andBool #EntrypointExists(KnownAddresses, To,           #token("%default", "FieldAnnotation"), #Type(unit))
+      andBool #LocalEntrypointExists(LocalEntrypoints, %updateTokenPoolInternal, #Type(#DexterVersionSpecificParamType(IsFA2)))
+      andBool #LocalEntrypointExists(LocalEntrypoints, %default,                 unit)
 endmodule
 ```
 
@@ -911,7 +931,7 @@ module DEXTER-TOKENTOXTZ-FA2-NEGATIVE-3-SPEC
         <selfIsUpdatingTokenPool> IsUpdating </selfIsUpdatingTokenPool>
         <myamount> #Mutez(Amount) </myamount>
         <mynow> #Timestamp(CurrentTime) </mynow>
-        <paramtype> %updateTokenPoolInternal |-> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype>
+        <paramtype> LocalEntrypoints </paramtype>
         <tokenPool> TokenPool </tokenPool>
         <xtzPool> #Mutez(XtzPool) </xtzPool>
         <tokenAddress> TokenAddress:Address </tokenAddress>
@@ -923,14 +943,16 @@ module DEXTER-TOKENTOXTZ-FA2-NEGATIVE-3-SPEC
       andBool CurrentTime <Int Deadline
       andBool (TokenPool >=Int 0)
       andBool (TokenPool >Int 0 orBool TokensSold >Int 0)
-      andBool #XtzBought(XtzPool, TokenPool, TokensSold) >=Int  MinXtzBought
-      andBool #XtzBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
+      andBool #CurrencyBought(XtzPool, TokenPool, TokensSold) >=Int  MinXtzBought
+      andBool #CurrencyBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
       andBool notBool ( #IsLegalMutezValue(MinXtzBought)
-                andBool #IsLegalMutezValue(#XtzBought(XtzPool, TokenPool, TokensSold))
-                andBool #IsLegalMutezValue(XtzPool:Int -Int #XtzBought (XtzPool:Int, TokenPool:Int, TokensSold:Int))
+                andBool #IsLegalMutezValue(#CurrencyBought(XtzPool, TokenPool, TokensSold))
+                andBool #IsLegalMutezValue(XtzPool:Int -Int #CurrencyBought (XtzPool:Int, TokenPool:Int, TokensSold:Int))
                       )
       andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer,                             #TokenTransferType(IsFA2))
       andBool #EntrypointExists(KnownAddresses, To,           #token("%default", "FieldAnnotation"), #Type(unit))
+      andBool #LocalEntrypointExists(LocalEntrypoints, %updateTokenPoolInternal, #Type(#DexterVersionSpecificParamType(IsFA2)))
+      andBool #LocalEntrypointExists(LocalEntrypoints, %default,                 unit)
 ```
 
 ```k
@@ -953,31 +975,33 @@ module DEXTER-XTZTOTOKEN-FA12-POSITIVE-SPEC
   imports DEXTER-VERIFICATION
   claim <k> #runProof(IsFA2, XtzToToken(To, MinTokensBought, #Timestamp(Deadline))) => . </k>
         <stack> .Stack </stack>
-        <paramtype> %updateTokenPoolInternal |-> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype>
+        <paramtype> LocalEntrypoints </paramtype>
         <selfIsUpdatingTokenPool> IsUpdating </selfIsUpdatingTokenPool>
         <myamount> #Mutez(Amount) </myamount>
         <tokenAddress> TokenAddress </tokenAddress>
         <xtzPool> #Mutez(XtzPool => XtzPool +Int Amount) </xtzPool>
-        <tokenPool> TokenPool => TokenPool -Int #XtzBought(TokenPool, XtzPool, Amount) </tokenPool>
+        <tokenPool> TokenPool => TokenPool -Int #CurrencyBought(TokenPool, XtzPool, Amount) </tokenPool>
         <mynow> #Timestamp(CurrentTime) </mynow>
         <myaddr> SelfAddress </myaddr>
         <nonce> #Nonce(N => N +Int 1) </nonce>
         <tokenId> TokenID </tokenId>
         <knownaddrs> KnownAddresses </knownaddrs>
         <operations> _
-                  => [ Transfer_tokens #TokenTransferData(IsFA2, SelfAddress, To, TokenID, #XtzBought(TokenPool, XtzPool, Amount)) #Mutez(0) TokenAddress . %transfer N ]
+                  => [ Transfer_tokens #TokenTransferData(IsFA2, SelfAddress, To, TokenID, #CurrencyBought(TokenPool, XtzPool, Amount)) #Mutez(0) TokenAddress . %transfer N ]
                   ;; .InternalList
         </operations>
     requires notBool IsFA2
      andBool notBool IsUpdating
      andBool CurrentTime <Int Deadline
      andBool (XtzPool >Int 0 orBool Amount >Int 0)
-     andBool #XtzBought(TokenPool, XtzPool, Amount) >=Int MinTokensBought
-     andBool #XtzBought(TokenPool, XtzPool, Amount) <=Int TokenPool
-     andBool TokenPool -Int #XtzBought ( TokenPool , XtzPool , Amount ) >=Int 0
+     andBool #CurrencyBought(TokenPool, XtzPool, Amount) >=Int MinTokensBought
+     andBool #CurrencyBought(TokenPool, XtzPool, Amount) <=Int TokenPool
+     andBool TokenPool -Int #CurrencyBought ( TokenPool , XtzPool , Amount ) >=Int 0
      andBool #IsLegalMutezValue(XtzPool +Int Amount)
 
      andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer, #TokenTransferType(IsFA2))
+     andBool #LocalEntrypointExists(LocalEntrypoints, %updateTokenPoolInternal, #Type(#DexterVersionSpecificParamType(IsFA2)))
+     andBool #LocalEntrypointExists(LocalEntrypoints, %default,                 unit)
 endmodule
 ```
 
@@ -986,7 +1010,7 @@ module DEXTER-XTZTOTOKEN-FA12-NEGATIVE-SPEC
   imports DEXTER-VERIFICATION
   claim <k> #runProof(IsFA2, XtzToToken(_To, MinTokensBought, #Timestamp(Deadline))) => Aborted(?_, ?_, ?_, ?_) </k>
         <stack> .Stack => ?_:FailedStack </stack>
-        <paramtype> %updateTokenPoolInternal |-> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype>
+        <paramtype> LocalEntrypoints </paramtype>
         <selfIsUpdatingTokenPool> IsUpdating </selfIsUpdatingTokenPool>
         <myamount> #Mutez(Amount) </myamount>
         <tokenAddress> TokenAddress </tokenAddress>
@@ -999,12 +1023,14 @@ module DEXTER-XTZTOTOKEN-FA12-NEGATIVE-SPEC
      andBool notBool ( notBool IsUpdating
                andBool CurrentTime <Int Deadline
                andBool (XtzPool >Int 0 orBool Amount >Int 0)
-               andBool #XtzBought(TokenPool, XtzPool, Amount) >=Int MinTokensBought
-               andBool #XtzBought(TokenPool, XtzPool, Amount) <=Int TokenPool
-               andBool TokenPool -Int #XtzBought ( TokenPool , XtzPool , Amount ) >=Int 0
+               andBool #CurrencyBought(TokenPool, XtzPool, Amount) >=Int MinTokensBought
+               andBool #CurrencyBought(TokenPool, XtzPool, Amount) <=Int TokenPool
+               andBool TokenPool -Int #CurrencyBought ( TokenPool , XtzPool , Amount ) >=Int 0
                andBool #IsLegalMutezValue(XtzPool +Int Amount)
                      )
      andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer, #TokenTransferType(IsFA2))
+     andBool #LocalEntrypointExists(LocalEntrypoints, %updateTokenPoolInternal, #Type(#DexterVersionSpecificParamType(IsFA2)))
+     andBool #LocalEntrypointExists(LocalEntrypoints, %default,                 unit)
 endmodule
 ```
 
@@ -1013,31 +1039,33 @@ module DEXTER-XTZTOTOKEN-FA2-POSITIVE-SPEC
   imports DEXTER-VERIFICATION
   claim <k> #runProof(IsFA2, XtzToToken(To, MinTokensBought, #Timestamp(Deadline))) => . </k>
         <stack> .Stack </stack>
-        <paramtype> %updateTokenPoolInternal |-> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype>
+        <paramtype> LocalEntrypoints </paramtype>
         <selfIsUpdatingTokenPool> IsUpdating </selfIsUpdatingTokenPool>
         <myamount> #Mutez(Amount) </myamount>
         <tokenAddress> TokenAddress </tokenAddress>
         <xtzPool> #Mutez(XtzPool => XtzPool +Int Amount) </xtzPool>
-        <tokenPool> TokenPool => TokenPool -Int #XtzBought(TokenPool, XtzPool, Amount) </tokenPool>
+        <tokenPool> TokenPool => TokenPool -Int #CurrencyBought(TokenPool, XtzPool, Amount) </tokenPool>
         <mynow> #Timestamp(CurrentTime) </mynow>
         <myaddr> SelfAddress </myaddr>
         <nonce> #Nonce(N => N +Int 1) </nonce>
         <tokenId> TokenID </tokenId>
         <knownaddrs> KnownAddresses </knownaddrs>
         <operations> _
-                  => [ Transfer_tokens #TokenTransferData(IsFA2, SelfAddress, To, TokenID, #XtzBought(TokenPool, XtzPool, Amount)) #Mutez(0) TokenAddress . %transfer N ]
+                  => [ Transfer_tokens #TokenTransferData(IsFA2, SelfAddress, To, TokenID, #CurrencyBought(TokenPool, XtzPool, Amount)) #Mutez(0) TokenAddress . %transfer N ]
                   ;; .InternalList
         </operations>
     requires IsFA2
      andBool notBool IsUpdating
      andBool CurrentTime <Int Deadline
      andBool (XtzPool >Int 0 orBool Amount >Int 0)
-     andBool #XtzBought(TokenPool, XtzPool, Amount) >=Int MinTokensBought
-     andBool #XtzBought(TokenPool, XtzPool, Amount) <=Int TokenPool
-     andBool TokenPool -Int #XtzBought ( TokenPool , XtzPool , Amount ) >=Int 0
+     andBool #CurrencyBought(TokenPool, XtzPool, Amount) >=Int MinTokensBought
+     andBool #CurrencyBought(TokenPool, XtzPool, Amount) <=Int TokenPool
+     andBool TokenPool -Int #CurrencyBought ( TokenPool , XtzPool , Amount ) >=Int 0
      andBool #IsLegalMutezValue(XtzPool +Int Amount)
 
      andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer, #TokenTransferType(IsFA2))
+     andBool #LocalEntrypointExists(LocalEntrypoints, %updateTokenPoolInternal, #Type(#DexterVersionSpecificParamType(IsFA2)))
+     andBool #LocalEntrypointExists(LocalEntrypoints, %default,                 unit)
 endmodule
 ```
 
@@ -1046,7 +1074,7 @@ module DEXTER-XTZTOTOKEN-FA2-NEGATIVE-SPEC
   imports DEXTER-VERIFICATION
   claim <k> #runProof(IsFA2, XtzToToken(_To, MinTokensBought, #Timestamp(Deadline))) => Aborted(?_, ?_, ?_, ?_) </k>
         <stack> .Stack => ?_:FailedStack </stack>
-        <paramtype> %updateTokenPoolInternal |-> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype>
+        <paramtype> LocalEntrypoints </paramtype>
         <selfIsUpdatingTokenPool> IsUpdating </selfIsUpdatingTokenPool>
         <myamount> #Mutez(Amount) </myamount>
         <tokenAddress> TokenAddress </tokenAddress>
@@ -1059,12 +1087,14 @@ module DEXTER-XTZTOTOKEN-FA2-NEGATIVE-SPEC
      andBool notBool ( notBool IsUpdating
                andBool CurrentTime <Int Deadline
                andBool (XtzPool >Int 0 orBool Amount >Int 0)
-               andBool #XtzBought(TokenPool, XtzPool, Amount) >=Int MinTokensBought
-               andBool #XtzBought(TokenPool, XtzPool, Amount) <=Int TokenPool
-               andBool TokenPool -Int #XtzBought ( TokenPool , XtzPool , Amount ) >=Int 0
+               andBool #CurrencyBought(TokenPool, XtzPool, Amount) >=Int MinTokensBought
+               andBool #CurrencyBought(TokenPool, XtzPool, Amount) <=Int TokenPool
+               andBool TokenPool -Int #CurrencyBought ( TokenPool , XtzPool , Amount ) >=Int 0
                andBool #IsLegalMutezValue(XtzPool +Int Amount)
                      )
      andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer, #TokenTransferType(IsFA2))
+     andBool #LocalEntrypointExists(LocalEntrypoints, %updateTokenPoolInternal, #Type(#DexterVersionSpecificParamType(IsFA2)))
+     andBool #LocalEntrypointExists(LocalEntrypoints, %default,                 unit)
 endmodule
 ```
 
@@ -1090,29 +1120,31 @@ A buyer sends tokens to the Dexter contract, converts its to xtz, and then immed
         <selfIsUpdatingTokenPool> SelfIsUpdating </selfIsUpdatingTokenPool>
         <myamount> #Mutez(Amount) </myamount>
         <tokenAddress> TokenAddress </tokenAddress>
-        <xtzPool> #Mutez(XtzPool => XtzPool -Int #XtzBought(XtzPool, TokenPool, TokensSold)) </xtzPool>
+        <xtzPool> #Mutez(XtzPool => XtzPool -Int #CurrencyBought(XtzPool, TokenPool, TokensSold)) </xtzPool>
         <tokenPool> TokenPool => TokenPool +Int TokensSold </tokenPool>
         <mynow> #Timestamp(CurrentTime) </mynow>
         <senderaddr> Sender </senderaddr>
         <myaddr> SelfAddress </myaddr>
-        <paramtype> %updateTokenPoolInternal |-> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype>
+        <paramtype> LocalEntrypoints </paramtype>
         <nonce> #Nonce(N => N +Int 2) </nonce>
         <tokenId> TokenID </tokenId>
         <knownaddrs> KnownAddresses </knownaddrs>
         <operations> _
-                  => [ Transfer_tokens #TokenTransferData(IsFA2, Sender, SelfAddress, TokenID, TokensSold) #Mutez(0)                                          TokenAddress         . %transfer    N        ]
-                  ;; [ Transfer_tokens Pair To Pair MinTokensBought #Timestamp(Deadline)                   #Mutez(#XtzBought(XtzPool, TokenPool, TokensSold)) OutputDexterContract . %xtzToToken (N +Int 1)]
+                  => [ Transfer_tokens #TokenTransferData(IsFA2, Sender, SelfAddress, TokenID, TokensSold) #Mutez(0)                                               TokenAddress         . %transfer    N        ]
+                  ;; [ Transfer_tokens Pair To Pair MinTokensBought #Timestamp(Deadline)                   #Mutez(#CurrencyBought(XtzPool, TokenPool, TokensSold)) OutputDexterContract . %xtzToToken (N +Int 1)]
                   ;; .InternalList
         </operations>
      requires notBool IsFA2
       andBool notBool SelfIsUpdating
       andBool CurrentTime <Int Deadline
       andBool Amount ==Int 0
-      andBool #XtzBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
+      andBool #CurrencyBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
       andBool (TokenPool >Int 0 orBool TokensSold >Int 0)
-      andBool #IsLegalMutezValue(#XtzBought(XtzPool, TokenPool, TokensSold))
+      andBool #IsLegalMutezValue(#CurrencyBought(XtzPool, TokenPool, TokensSold))
       andBool #EntrypointExists(KnownAddresses, TokenAddress,         %transfer,   #TokenTransferType(IsFA2))
       andBool #EntrypointExists(KnownAddresses, OutputDexterContract, %xtzToToken, pair (address %to) (pair (nat %minTokensBought) (timestamp %deadline)))
+      andBool #LocalEntrypointExists(LocalEntrypoints, %updateTokenPoolInternal, #Type(#DexterVersionSpecificParamType(IsFA2)))
+      andBool #LocalEntrypointExists(LocalEntrypoints, %default,                 unit)
 ```
 
 ```k
@@ -1121,29 +1153,31 @@ A buyer sends tokens to the Dexter contract, converts its to xtz, and then immed
         <selfIsUpdatingTokenPool> SelfIsUpdating </selfIsUpdatingTokenPool>
         <myamount> #Mutez(Amount) </myamount>
         <tokenAddress> TokenAddress </tokenAddress>
-        <xtzPool> #Mutez(XtzPool => XtzPool -Int #XtzBought(XtzPool, TokenPool, TokensSold)) </xtzPool>
+        <xtzPool> #Mutez(XtzPool => XtzPool -Int #CurrencyBought(XtzPool, TokenPool, TokensSold)) </xtzPool>
         <tokenPool> TokenPool => TokenPool +Int TokensSold </tokenPool>
         <mynow> #Timestamp(CurrentTime) </mynow>
         <senderaddr> Sender </senderaddr>
         <myaddr> SelfAddress </myaddr>
-        <paramtype> %updateTokenPoolInternal |-> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype>
+        <paramtype> LocalEntrypoints </paramtype>
         <nonce> #Nonce(N => N +Int 2) </nonce>
         <tokenId> TokenID </tokenId>
         <knownaddrs> KnownAddresses </knownaddrs>
         <operations> _
-                  => [ Transfer_tokens #TokenTransferData(IsFA2, Sender, SelfAddress, TokenID, TokensSold) #Mutez(0)                                          TokenAddress         . %transfer    N        ]
-                  ;; [ Transfer_tokens Pair To Pair MinTokensBought #Timestamp(Deadline)                   #Mutez(#XtzBought(XtzPool, TokenPool, TokensSold)) OutputDexterContract . %xtzToToken (N +Int 1)]
+                  => [ Transfer_tokens #TokenTransferData(IsFA2, Sender, SelfAddress, TokenID, TokensSold) #Mutez(0)                                               TokenAddress         . %transfer    N        ]
+                  ;; [ Transfer_tokens Pair To Pair MinTokensBought #Timestamp(Deadline)                   #Mutez(#CurrencyBought(XtzPool, TokenPool, TokensSold)) OutputDexterContract . %xtzToToken (N +Int 1)]
                   ;; .InternalList
         </operations>
      requires IsFA2
       andBool notBool SelfIsUpdating
       andBool CurrentTime <Int Deadline
       andBool Amount ==Int 0
-      andBool #XtzBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
+      andBool #CurrencyBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
       andBool (TokenPool >Int 0 orBool TokensSold >Int 0)
-      andBool #IsLegalMutezValue(#XtzBought(XtzPool, TokenPool, TokensSold))
+      andBool #IsLegalMutezValue(#CurrencyBought(XtzPool, TokenPool, TokensSold))
       andBool #EntrypointExists(KnownAddresses, TokenAddress,         %transfer,   #TokenTransferType(IsFA2))
       andBool #EntrypointExists(KnownAddresses, OutputDexterContract, %xtzToToken, pair (address %to) (pair (nat %minTokensBought) (timestamp %deadline)))
+      andBool #LocalEntrypointExists(LocalEntrypoints, %updateTokenPoolInternal, #Type(#DexterVersionSpecificParamType(IsFA2)))
+      andBool #LocalEntrypointExists(LocalEntrypoints, %default,                 unit)
 ```
 
 ```k
@@ -1156,7 +1190,7 @@ module DEXTER-TOKENTOTOKEN-NEGATIVE-SPEC
 ```
 
 ```k
-  claim <k> #runProof(IsFA2, TokenToToken(OutputDexterContract, MinTokensBought, To, TokensSold, #Timestamp(Deadline)))
+  claim <k> #runProof(IsFA2, TokenToToken(OutputDexterContract, _MinTokensBought, _To, TokensSold, #Timestamp(Deadline)))
          => Aborted (?_, ?_, ?_, ?_ )
         </k>
         <stack> .Stack => ?_:FailedStack </stack>
@@ -1166,27 +1200,29 @@ module DEXTER-TOKENTOTOKEN-NEGATIVE-SPEC
         <xtzPool> #Mutez(XtzPool) </xtzPool>
         <tokenPool> TokenPool </tokenPool>
         <mynow> #Timestamp(CurrentTime) </mynow>
-        <senderaddr> Sender </senderaddr>
-        <myaddr> SelfAddress </myaddr>
-        <paramtype> %updateTokenPoolInternal |-> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype>
-        <nonce> #Nonce(N => ?_) </nonce>
-        <tokenId> TokenID </tokenId>
+        <senderaddr> _Sender </senderaddr>
+        <myaddr> _SelfAddress </myaddr>
+        <paramtype> LocalEntrypoints </paramtype>
+        <nonce> #Nonce(_N => ?_) </nonce>
+        <tokenId> _TokenID </tokenId>
         <knownaddrs> KnownAddresses </knownaddrs>
         <operations> _ </operations>
      requires notBool IsFA2
       andBool notBool( notBool SelfIsUpdating
                andBool CurrentTime <Int Deadline
                andBool Amount ==Int 0
-               andBool #XtzBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
+               andBool #CurrencyBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
                andBool (TokenPool >Int 0 orBool TokensSold >Int 0)
-               andBool #IsLegalMutezValue(#XtzBought(XtzPool, TokenPool, TokensSold))
+               andBool #IsLegalMutezValue(#CurrencyBought(XtzPool, TokenPool, TokensSold))
                      )
       andBool #EntrypointExists(KnownAddresses, TokenAddress,         %transfer,   #TokenTransferType(IsFA2))
       andBool #EntrypointExists(KnownAddresses, OutputDexterContract, %xtzToToken, pair (address %to) (pair (nat %minTokensBought) (timestamp %deadline)))
+      andBool #LocalEntrypointExists(LocalEntrypoints, %updateTokenPoolInternal, #Type(#DexterVersionSpecificParamType(IsFA2)))
+      andBool #LocalEntrypointExists(LocalEntrypoints, %default,                 unit)
 ```
 
 ```k
-  claim <k> #runProof(IsFA2, TokenToToken(OutputDexterContract, MinTokensBought, To, TokensSold, #Timestamp(Deadline)))
+  claim <k> #runProof(IsFA2, TokenToToken(OutputDexterContract, _MinTokensBought, _To, TokensSold, #Timestamp(Deadline)))
          => Aborted (?_, ?_, ?_, ?_ )
         </k>
         <stack> .Stack => ?_:FailedStack </stack>
@@ -1196,23 +1232,25 @@ module DEXTER-TOKENTOTOKEN-NEGATIVE-SPEC
         <xtzPool> #Mutez(XtzPool) </xtzPool>
         <tokenPool> TokenPool </tokenPool>
         <mynow> #Timestamp(CurrentTime) </mynow>
-        <senderaddr> Sender </senderaddr>
-        <myaddr> SelfAddress </myaddr>
-        <paramtype> %updateTokenPoolInternal |-> #Type(#DexterVersionSpecificParamType(IsFA2)) </paramtype>
-        <nonce> #Nonce(N => ?_) </nonce>
-        <tokenId> TokenID </tokenId>
+        <senderaddr> _Sender </senderaddr>
+        <myaddr> _SelfAddress </myaddr>
+        <paramtype> LocalEntrypoints </paramtype>
+        <nonce> #Nonce(_N => ?_) </nonce>
+        <tokenId> _TokenID </tokenId>
         <knownaddrs> KnownAddresses </knownaddrs>
         <operations> _ </operations>
      requires IsFA2
       andBool notBool( notBool SelfIsUpdating
                andBool CurrentTime <Int Deadline
                andBool Amount ==Int 0
-               andBool #XtzBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
+               andBool #CurrencyBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
                andBool (TokenPool >Int 0 orBool TokensSold >Int 0)
-               andBool #IsLegalMutezValue(#XtzBought(XtzPool, TokenPool, TokensSold))
+               andBool #IsLegalMutezValue(#CurrencyBought(XtzPool, TokenPool, TokensSold))
                      )
       andBool #EntrypointExists(KnownAddresses, TokenAddress,         %transfer,   #TokenTransferType(IsFA2))
       andBool #EntrypointExists(KnownAddresses, OutputDexterContract, %xtzToToken, pair (address %to) (pair (nat %minTokensBought) (timestamp %deadline)))
+      andBool #LocalEntrypointExists(LocalEntrypoints, %updateTokenPoolInternal, #Type(#DexterVersionSpecificParamType(IsFA2)))
+      andBool #LocalEntrypointExists(LocalEntrypoints, %default,                 unit)
 ```
 
 ```k

--- a/tests/proofs/dexter/dexter.md
+++ b/tests/proofs/dexter/dexter.md
@@ -585,6 +585,11 @@ If the contract execution fails, storage is not updated.
   rule #TokenBalanceEntrypoint(TokenAddr, false) => TokenAddr . %getBalance
   rule #TokenBalanceEntrypoint(TokenAddr, true ) => TokenAddr . %balance_of
 
+  syntax Type ::= #TokenBalanceEntrypointType(Bool) [function, functional]
+ // ----------------------------------------------------------------------
+  rule #TokenBalanceEntrypointType(false) => #Type(pair address (contract nat))
+  rule #TokenBalanceEntrypointType(true)  => #Type(pair (list (pair address nat)) (contract (list (pair (pair (address) nat) nat))))
+
   syntax Int ::= #ceildiv   (Int, Int) [function]
                | #ceildivAux(Int, Int) [function, functional]
  // ---------------------------------------------------------

--- a/tests/proofs/dexter/dexter.md
+++ b/tests/proofs/dexter/dexter.md
@@ -593,22 +593,11 @@ If the contract execution fails, storage is not updated.
   rule #ceildivAux(X, Y) => X /Int Y          requires Y  =/=Int 0 andBool         X %Int Y ==Int 0
   rule #ceildivAux(X, Y) => X /Int Y +Int 1   requires Y  =/=Int 0 andBool notBool X %Int Y ==Int 0
 
-  syntax Int ::= #XtzBought   (Int, Int, Int) [function, functional, smtlib(xtzbought), no-evaluators]
- // -----------------------------------------
-  rule (TokensSold *Int 997 *Int XtzPool) /Int (TokenPool *Int 1000 +Int (TokensSold *Int 997))
-    => #XtzBought(XtzPool, TokenPool, TokensSold)
+  syntax Int ::= #CurrencyBought(Int, Int, Int) [function, functional, smtlib(xtzbought), no-evaluators]
+ // ----------------------------------------------------------------------------------------------------
+  rule (ToSellAmt *Int 997 *Int ToBuyCurrencyTotal) /Int (ToSellCurrencyTotal *Int 1000 +Int (ToSellAmt *Int 997))
+    => #CurrencyBought(ToBuyCurrencyTotal, ToSellCurrencyTotal, ToSellAmt)
     [simplification]
-```
-
-We'd like to additionally define `#TokensBought`, however this has the same structure as `#XtzBought`
-and so we can't have simplification rules for both.
-
-```k
- // syntax Int ::= #TokensBought(Int, Int, Int) [function, functional, smtlib(tokensbought), no-evaluators]
- // ----------------------------------------
- // rule (Amount *Int 997 *Int TokenPool) /Int (XtzPool *Int 1000 +Int (Amount *Int 997))
- //   => #TokensBought(XtzPool, TokenPool, XtzSold)
- //   [simplification]
 ```
 
 ```k
@@ -617,6 +606,13 @@ and so we can't have simplification rules for both.
   rule #EntrypointExists(KnownAddresses, Addr, FieldAnnot, EntrypointType)
     => Addr . FieldAnnot  in_keys(KnownAddresses) andBool
        KnownAddresses[Addr . FieldAnnot] ==K #Name(EntrypointType)
+    [macro]
+
+  syntax Bool ::= #LocalEntrypointExists(Map, FieldAnnotation, Type)
+ // ----------------------------------------------------------------
+  rule #LocalEntrypointExists(LocalEntrypoints, FieldAnnot, EntrypointType)
+    => FieldAnnot in_keys(LocalEntrypoints) andBool
+       LocalEntrypoints[FieldAnnot] ==K #Name(EntrypointType)
     [macro]
 ```
 

--- a/tests/proofs/liquidity-baking/lb-compiled.md
+++ b/tests/proofs/liquidity-baking/lb-compiled.md
@@ -26,7 +26,6 @@ Since we work with specific code that contains a finite number of annotations, w
 
 ```k
   syntax FieldAnnotation ::= "%deadline"
-                           | "%default"
                            | "%minTokensBought"
                            | "%mintOrBurn"
                            | "%quantity"
@@ -37,7 +36,6 @@ Since we work with specific code that contains a finite number of annotations, w
  // --------------------------------------
 
   rule %deadline                => #token("%deadline"               , "FieldAnnotation") [macro]
-  rule %default                 => #token("%default"                , "FieldAnnotation") [macro]
   rule %minTokensBought         => #token("%minTokensBought"        , "FieldAnnotation") [macro]
   rule %mintOrBurn              => #token("%mintOrBurn"             , "FieldAnnotation") [macro]
   rule %quantity                => #token("%quantity"               , "FieldAnnotation") [macro]

--- a/tests/proofs/liquidity-baking/lb-compiled.md
+++ b/tests/proofs/liquidity-baking/lb-compiled.md
@@ -22,27 +22,17 @@ We have pasted the code verbatim:
 
 Annotations are arbitrary tokens.
 The set of permissible annotations is infinite.
-Since we work with specific code that contains a finite number of annotations, we can represent each and give it a macro for wrapping it in the `#token(...)` production.
+Since we work with specific code that contains a finite number of annotations, we can represent each and give it a `[token]` marker.
 
 ```k
-  syntax FieldAnnotation ::= "%deadline"
-                           | "%minTokensBought"
-                           | "%mintOrBurn"
-                           | "%quantity"
-                           | "%target"
-                           | "%to"
-                           | "%transfer"
-                           | "%xtzToToken"
- // --------------------------------------
-
-  rule %deadline                => #token("%deadline"               , "FieldAnnotation") [macro]
-  rule %minTokensBought         => #token("%minTokensBought"        , "FieldAnnotation") [macro]
-  rule %mintOrBurn              => #token("%mintOrBurn"             , "FieldAnnotation") [macro]
-  rule %quantity                => #token("%quantity"               , "FieldAnnotation") [macro]
-  rule %target                  => #token("%target"                 , "FieldAnnotation") [macro]
-  rule %to                      => #token("%to"                     , "FieldAnnotation") [macro]
-  rule %transfer                => #token("%transfer"               , "FieldAnnotation") [macro]
-  rule %xtzToToken              => #token("%xtzToToken"             , "FieldAnnotation") [macro]
+  syntax FieldAnnotation ::= "%deadline"        [token]
+                           | "%minTokensBought" [token]
+                           | "%mintOrBurn"      [token]
+                           | "%quantity"        [token]
+                           | "%target"          [token]
+                           | "%to"              [token]
+                           | "%transfer"        [token]
+                           | "%xtzToToken"      [token]
 ```
 
 Each Tezos account has an address. We make a macro which stores the null address to simplify our proof scripts.

--- a/tests/proofs/liquidity-baking/lb-spec.md
+++ b/tests/proofs/liquidity-baking/lb-spec.md
@@ -71,10 +71,10 @@ We have one case for when `#ceildiv` results in an upwards rounding, and one for
         <senderaddr> Sender </senderaddr>
         <nonce> #Nonce(Nonce => Nonce +Int 2) </nonce>
         <knownaddrs> KnownAddresses </knownaddrs>
-        <paramtype> #Type(#LiquidityBakingParamType()) </paramtype>
+        <paramtype> %default |-> #Type(#LiquidityBakingParamType()) </paramtype>
         <operations> _
-                  => [ Transfer_tokens #TokenTransferData(Sender, SelfAddress, #ceildiv(Amount *Int TokenAmount, XtzAmount)) #Mutez(0) TokenAddress Nonce ] ;;
-                     [ Transfer_tokens Pair ((Amount *Int OldLqt) /Int XtzAmount) Owner #Mutez(0) LqtAddress (Nonce +Int 1) ] ;;
+                  => [ Transfer_tokens #TokenTransferData(Sender, SelfAddress, #ceildiv(Amount *Int TokenAmount, XtzAmount)) #Mutez(0) TokenAddress . %transfer    Nonce ] ;;
+                     [ Transfer_tokens Pair ((Amount *Int OldLqt) /Int XtzAmount) Owner                                      #Mutez(0) LqtAddress   . %mintOrBurn (Nonce +Int 1) ] ;;
                      .InternalList
         </operations>
     requires CurrentTime <Int Deadline
@@ -102,10 +102,10 @@ We have one case for when `#ceildiv` results in an upwards rounding, and one for
         <senderaddr> Sender </senderaddr>
         <nonce> #Nonce(Nonce => Nonce +Int 2) </nonce>
         <knownaddrs> KnownAddresses </knownaddrs>
-        <paramtype> #Type(#LiquidityBakingParamType()) </paramtype>
+        <paramtype> %default |-> #Type(#LiquidityBakingParamType()) </paramtype>
         <operations> _
-                  => [ Transfer_tokens #TokenTransferData(Sender, SelfAddress, #ceildiv(Amount *Int TokenAmount, XtzAmount)) #Mutez(0) TokenAddress Nonce ] ;;
-                     [ Transfer_tokens Pair ((Amount *Int OldLqt) /Int XtzAmount) Owner #Mutez(0) LqtAddress (Nonce +Int 1) ] ;;
+                  => [ Transfer_tokens #TokenTransferData(Sender, SelfAddress, #ceildiv(Amount *Int TokenAmount, XtzAmount)) #Mutez(0) TokenAddress . %transfer    Nonce ] ;;
+                     [ Transfer_tokens Pair ((Amount *Int OldLqt) /Int XtzAmount) Owner                                      #Mutez(0) LqtAddress   . %mintOrBurn (Nonce +Int 1) ] ;;
                      .InternalList
         </operations>
     requires CurrentTime <Int Deadline
@@ -185,11 +185,11 @@ module LIQUIDITY-BAKING-REMOVELIQUIDITY-POSITIVE-SPEC
         <senderaddr> Sender </senderaddr>
         <nonce> #Nonce(Nonce => Nonce +Int 3) </nonce>
         <knownaddrs> KnownAddresses </knownaddrs>
-        <paramtype> #Type(#LiquidityBakingParamType()) </paramtype> // 1027
+        <paramtype> %default |-> #Type(#LiquidityBakingParamType()) </paramtype> // 1027
         <operations> _
-                  => [ Transfer_tokens (Pair (0 -Int LqtBurned) Sender) #Mutez(0) LqtAddress Nonce ] ;;
-                     [ Transfer_tokens #TokenTransferData(SelfAddress, To, (LqtBurned *Int TokenAmount) /Int OldLqt) #Mutez(0) TokenAddress (Nonce +Int 1) ] ;;
-                     [ Transfer_tokens Unit #Mutez((LqtBurned *Int XtzAmount) /Int OldLqt) To (Nonce +Int 2) ] ;;
+                  => [ Transfer_tokens (Pair (0 -Int LqtBurned) Sender)                                              #Mutez(0)                                      LqtAddress . %mintOrBurn  Nonce         ] ;;
+                     [ Transfer_tokens #TokenTransferData(SelfAddress, To, (LqtBurned *Int TokenAmount) /Int OldLqt) #Mutez(0)                                      TokenAddress . %transfer (Nonce +Int 1) ] ;;
+                     [ Transfer_tokens Unit                                                                          #Mutez((LqtBurned *Int XtzAmount) /Int OldLqt) To . %default            (Nonce +Int 2) ] ;;
                      .InternalList
         </operations>
     requires CurrentTime <Int Deadline
@@ -296,14 +296,14 @@ A buyer sends tokens to the Liquidity Baking contract and receives a correspondi
         <tokenPool> TokenPool => TokenPool +Int TokensSold </tokenPool>
         <mynow> #Timestamp(CurrentTime) </mynow>
         <senderaddr> Sender </senderaddr>
-        <paramtype> #Type(#LiquidityBakingParamType()) </paramtype>
+        <paramtype> %default |-> #Type(#LiquidityBakingParamType()) </paramtype>
         <myaddr> SelfAddress:Address </myaddr>
         <nonce> #Nonce(N => N +Int 3) </nonce>
         <knownaddrs> KnownAddresses </knownaddrs>
         <operations> _
-                  => [ Transfer_tokens #TokenTransferData(Sender, SelfAddress, TokensSold) #Mutez(0)                                                    TokenAddress  N        ]
-                  ;; [ Transfer_tokens Unit                                                #Mutez(#XtzBought(XtzPool, TokenPool, TokensSold))           To           (N +Int 1)]
-                  ;; [ Transfer_tokens Unit                                                #Mutez(#XtzBurn(#XtzBought(XtzPool, TokenPool, TokensSold))) null_address (N +Int 2)]
+                  => [ Transfer_tokens #TokenTransferData(Sender, SelfAddress, TokensSold) #Mutez(0)                                                    TokenAddress . %transfer N        ]
+                  ;; [ Transfer_tokens Unit                                                #Mutez(#XtzBought(XtzPool, TokenPool, TokensSold))           To           . %default (N +Int 1)]
+                  ;; [ Transfer_tokens Unit                                                #Mutez(#XtzBurn(#XtzBought(XtzPool, TokenPool, TokensSold))) null_address . %default (N +Int 2)]
                   ;; .InternalList
         </operations>
      requires Amount ==Int 0
@@ -331,7 +331,7 @@ module LIQUIDITY-BAKING-TOKENTOXTZ-NEGATIVE-1-SPEC
         <mynow> #Timestamp(CurrentTime) </mynow>
         <myamount> #Mutez(Amount) </myamount>
         <tokenAddress> _TokenAddress:Address </tokenAddress>
-        <paramtype> #Type(#LiquidityBakingParamType()) </paramtype>
+        <paramtype> %default |-> #Type(#LiquidityBakingParamType()) </paramtype>
      requires notBool Amount ==Int 0
          orBool notBool CurrentTime <Int Deadline
 endmodule
@@ -347,7 +347,7 @@ module LIQUIDITY-BAKING-TOKENTOXTZ-NEGATIVE-2-SPEC
         <tokenAddress> TokenAddress:Address </tokenAddress>
         <xtzPool> #Mutez(_XtzPool) </xtzPool>
         <tokenPool> TokenPool </tokenPool>
-        <paramtype> #Type(#LiquidityBakingParamType()) </paramtype>
+        <paramtype> %default |-> #Type(#LiquidityBakingParamType()) </paramtype>
      requires notBool Amount ==Int 0
       andBool notBool CurrentTime <Int Deadline
       andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer, #TokenTransferType())
@@ -367,7 +367,7 @@ module LIQUIDITY-BAKING-TOKENTOXTZ-NEGATIVE-3-SPEC
         <tokenAddress> TokenAddress:Address </tokenAddress>
         <xtzPool> #Mutez(XtzPool) </xtzPool>
         <tokenPool> TokenPool </tokenPool>
-        <paramtype> #Type(#LiquidityBakingParamType()) </paramtype>
+        <paramtype> %default |-> #Type(#LiquidityBakingParamType()) </paramtype>
      requires notBool Amount ==Int 0
       andBool notBool CurrentTime <Int Deadline
       andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer, #TokenTransferType())
@@ -389,7 +389,7 @@ module LIQUIDITY-BAKING-TOKENTOXTZ-NEGATIVE-4-SPEC
         <tokenAddress> TokenAddress:Address </tokenAddress>
         <xtzPool> #Mutez(XtzPool) </xtzPool>
         <tokenPool> TokenPool </tokenPool>
-        <paramtype> #Type(#LiquidityBakingParamType()) </paramtype>
+        <paramtype> %default |-> #Type(#LiquidityBakingParamType()) </paramtype>
      requires notBool Amount ==Int 0
       andBool notBool CurrentTime <Int Deadline
       andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer, #TokenTransferType())
@@ -417,7 +417,7 @@ module LIQUIDITY-BAKING-XTZTOTOKEN-POSITIVE-SPEC
   imports LIQUIDITY-BAKING-VERIFICATION
   claim <k> #runProof(XtzToToken(To, MinTokensBought, #Timestamp(Deadline))) => . </k>
         <stack> .Stack </stack>
-        <paramtype> #Type(#LiquidityBakingParamType()) </paramtype>
+        <paramtype> %default |-> #Type(#LiquidityBakingParamType()) </paramtype>
         <myamount> #Mutez(Amount) </myamount>
         <tokenAddress> TokenAddress </tokenAddress>
         <xtzPool> #Mutez(XtzPool => XtzPool +Int Amount) </xtzPool>
@@ -427,7 +427,8 @@ module LIQUIDITY-BAKING-XTZTOTOKEN-POSITIVE-SPEC
         <nonce> #Nonce(N => N +Int 1) </nonce>
         <knownaddrs> KnownAddresses </knownaddrs>
         <operations> _
-                  => [ Transfer_tokens #TokenTransferData(SelfAddress, To, #XtzBought(TokenPool, XtzPool, Amount)) #Mutez(0) TokenAddress N ]
+                  => [ Transfer_tokens #TokenTransferData(SelfAddress, To, #XtzBought(TokenPool, XtzPool, Amount)) #Mutez(0)                                                TokenAddress . %transfer N        ]
+                  ;; [ Transfer_tokens Unit                                                                        #Mutez(#XtzBurn(#XtzBought(TokenPool, XtzPool, Amount))) null_address . %default (N +Int 2)]
                   ;; .InternalList
         </operations>
     requires CurrentTime <Int Deadline
@@ -447,7 +448,7 @@ module LIQUIDITY-BAKING-XTZTOTOKEN-NEGATIVE-SPEC
   imports LIQUIDITY-BAKING-VERIFICATION
   claim <k> #runProof(XtzToToken(_To, MinTokensBought, #Timestamp(Deadline))) => Aborted(?_, ?_, ?_, ?_) </k>
         <stack> .Stack => ?_:FailedStack </stack>
-        <paramtype> #Type(#LiquidityBakingParamType()) </paramtype>
+        <paramtype> %default |-> #Type(#LiquidityBakingParamType()) </paramtype>
         <myamount> #Mutez(Amount) </myamount>
         <tokenAddress> TokenAddress </tokenAddress>
         <xtzPool> #Mutez(XtzPool) </xtzPool>
@@ -492,12 +493,13 @@ A buyer sends tokens to the Liquidity Baking contract, converts its to xtz, and 
         <mynow> #Timestamp(CurrentTime) </mynow>
         <senderaddr> Sender </senderaddr>
         <myaddr> SelfAddress </myaddr>
-        <paramtype> #Type(#LiquidityBakingParamType()) </paramtype>
-        <nonce> #Nonce(N => N +Int 2) </nonce>
+        <paramtype> %default |-> #Type(#LiquidityBakingParamType()) </paramtype>
+        <nonce> #Nonce(N => N +Int 3) </nonce>
         <knownaddrs> KnownAddresses </knownaddrs>
         <operations> _
-                  => [ Transfer_tokens #TokenTransferData(Sender, SelfAddress, TokensSold) #Mutez(0)                                          TokenAddress          N        ]
-                  ;; [ Transfer_tokens Pair To Pair MinTokensBought #Timestamp(Deadline)   #Mutez(#XtzBought(XtzPool, TokenPool, TokensSold)) OutputDexterContract (N +Int 1)]
+                  => [ Transfer_tokens #TokenTransferData(Sender, SelfAddress, TokensSold) #Mutez(0)                                                    TokenAddress         . %transfer    N        ]
+                  ;; [ Transfer_tokens Pair To Pair MinTokensBought #Timestamp(Deadline)   #Mutez(#XtzBought(XtzPool, TokenPool, TokensSold))           OutputDexterContract . %xtzToToken (N +Int 1)]
+                  ;; [ Transfer_tokens Pair To Pair MinTokensBought #Timestamp(Deadline)   #Mutez(#XtzBurn(#XtzBought(XtzPool, TokenPool, TokensSold))) null_address         . %xtzToToken (N +Int 2)]
                   ;; .InternalList
         </operations>
      requires CurrentTime <Int Deadline
@@ -520,7 +522,7 @@ module LIQUIDITY-BAKING-TOKENTOTOKEN-NEGATIVE-SPEC
 ```
 
 ```k
-  claim <k> #runProof(TokenToToken(OutputDexterContract, MinTokensBought, To, TokensSold, #Timestamp(Deadline)))
+  claim <k> #runProof(TokenToToken(OutputDexterContract, _MinTokensBought, _To, TokensSold, #Timestamp(Deadline)))
          => Aborted (?_, ?_, ?_, ?_ )
         </k>
         <stack> .Stack => ?_:FailedStack </stack>
@@ -529,10 +531,10 @@ module LIQUIDITY-BAKING-TOKENTOTOKEN-NEGATIVE-SPEC
         <xtzPool> #Mutez(XtzPool) </xtzPool>
         <tokenPool> TokenPool </tokenPool>
         <mynow> #Timestamp(CurrentTime) </mynow>
-        <senderaddr> Sender </senderaddr>
-        <myaddr> SelfAddress </myaddr>
-        <paramtype> #Type(#LiquidityBakingParamType()) </paramtype>
-        <nonce> #Nonce(N => ?_) </nonce>
+        <senderaddr> _Sender </senderaddr>
+        <myaddr> _SelfAddress </myaddr>
+        <paramtype> %default |-> #Type(#LiquidityBakingParamType()) </paramtype>
+        <nonce> #Nonce(_N => ?_) </nonce>
         <knownaddrs> KnownAddresses </knownaddrs>
         <operations> _ </operations>
      requires notBool( CurrentTime <Int Deadline

--- a/tests/proofs/liquidity-baking/lb-spec.md
+++ b/tests/proofs/liquidity-baking/lb-spec.md
@@ -71,7 +71,7 @@ We have one case for when `#ceildiv` results in an upwards rounding, and one for
         <senderaddr> Sender </senderaddr>
         <nonce> #Nonce(Nonce => Nonce +Int 2) </nonce>
         <knownaddrs> KnownAddresses </knownaddrs>
-        <paramtype> %default |-> #Type(#LiquidityBakingParamType()) </paramtype>
+        <paramtype> LocalEntrypoints </paramtype>
         <operations> _
                   => [ Transfer_tokens #TokenTransferData(Sender, SelfAddress, #ceildiv(Amount *Int TokenAmount, XtzAmount)) #Mutez(0) TokenAddress . %transfer    Nonce ] ;;
                      [ Transfer_tokens Pair ((Amount *Int OldLqt) /Int XtzAmount) Owner                                      #Mutez(0) LqtAddress   . %mintOrBurn (Nonce +Int 1) ] ;;
@@ -86,6 +86,7 @@ We have one case for when `#ceildiv` results in an upwards rounding, and one for
 
      andBool #EntrypointExists(KnownAddresses, TokenAddress,   %transfer, #TokenTransferType())
      andBool #EntrypointExists(KnownAddresses,   LqtAddress, %mintOrBurn, pair int %quantity .AnnotationList address %target .AnnotationList)
+     andBool #LocalEntrypoints(LocalEntrypoints, %default, unit)
 ```
 
 ```k
@@ -102,7 +103,7 @@ We have one case for when `#ceildiv` results in an upwards rounding, and one for
         <senderaddr> Sender </senderaddr>
         <nonce> #Nonce(Nonce => Nonce +Int 2) </nonce>
         <knownaddrs> KnownAddresses </knownaddrs>
-        <paramtype> %default |-> #Type(#LiquidityBakingParamType()) </paramtype>
+        <paramtype> LocalEntrypoints </paramtype>
         <operations> _
                   => [ Transfer_tokens #TokenTransferData(Sender, SelfAddress, #ceildiv(Amount *Int TokenAmount, XtzAmount)) #Mutez(0) TokenAddress . %transfer    Nonce ] ;;
                      [ Transfer_tokens Pair ((Amount *Int OldLqt) /Int XtzAmount) Owner                                      #Mutez(0) LqtAddress   . %mintOrBurn (Nonce +Int 1) ] ;;
@@ -116,6 +117,7 @@ We have one case for when `#ceildiv` results in an upwards rounding, and one for
      andBool (Amount *Int TokenAmount) %Int XtzAmount =/=Int 0
      andBool #EntrypointExists(KnownAddresses, TokenAddress,   %transfer, #TokenTransferType())
      andBool #EntrypointExists(KnownAddresses,   LqtAddress, %mintOrBurn, pair int %quantity .AnnotationList address %target .AnnotationList)
+     andBool #LocalEntrypoints(LocalEntrypoints, %default, unit)
 ```
 
 ```k
@@ -185,7 +187,7 @@ module LIQUIDITY-BAKING-REMOVELIQUIDITY-POSITIVE-SPEC
         <senderaddr> Sender </senderaddr>
         <nonce> #Nonce(Nonce => Nonce +Int 3) </nonce>
         <knownaddrs> KnownAddresses </knownaddrs>
-        <paramtype> %default |-> #Type(#LiquidityBakingParamType()) </paramtype> // 1027
+        <paramtype> LocalEntrypoints </paramtype> // 1027
         <operations> _
                   => [ Transfer_tokens (Pair (0 -Int LqtBurned) Sender)                                              #Mutez(0)                                      LqtAddress . %mintOrBurn  Nonce         ] ;;
                      [ Transfer_tokens #TokenTransferData(SelfAddress, To, (LqtBurned *Int TokenAmount) /Int OldLqt) #Mutez(0)                                      TokenAddress . %transfer (Nonce +Int 1) ] ;;
@@ -200,6 +202,7 @@ module LIQUIDITY-BAKING-REMOVELIQUIDITY-POSITIVE-SPEC
      andBool #EntrypointExists(KnownAddresses, TokenAddress,   %transfer, #TokenTransferType())
      andBool #EntrypointExists(KnownAddresses,   LqtAddress, %mintOrBurn, pair int %quantity .AnnotationList address %target .AnnotationList)
      andBool #EntrypointExists(KnownAddresses,           To,    %default, #Type(unit))
+     andBool #LocalEntrypoints(LocalEntrypoints, %default, unit)
 
      andBool #IsLegalMutezValue(XtzAmount)
      andBool #IsLegalMutezValue((LqtBurned *Int XtzAmount) /Int OldLqt)
@@ -296,7 +299,7 @@ A buyer sends tokens to the Liquidity Baking contract and receives a correspondi
         <tokenPool> TokenPool => TokenPool +Int TokensSold </tokenPool>
         <mynow> #Timestamp(CurrentTime) </mynow>
         <senderaddr> Sender </senderaddr>
-        <paramtype> %default |-> #Type(#LiquidityBakingParamType()) </paramtype>
+        <paramtype> LocalEntrypoints </paramtype>
         <myaddr> SelfAddress:Address </myaddr>
         <nonce> #Nonce(N => N +Int 3) </nonce>
         <knownaddrs> KnownAddresses </knownaddrs>
@@ -318,6 +321,8 @@ A buyer sends tokens to the Liquidity Baking contract and receives a correspondi
       andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer, #TokenTransferType())
       andBool #EntrypointExists(KnownAddresses, To,           %default,  #Type(unit))
       andBool #EntrypointExists(KnownAddresses, null_address, %default,  #Type(unit))
+
+      andBool #LocalEntrypointExists(LocalEntrypoints, %default, unit)
 endmodule
 ```
 
@@ -331,7 +336,7 @@ module LIQUIDITY-BAKING-TOKENTOXTZ-NEGATIVE-1-SPEC
         <mynow> #Timestamp(CurrentTime) </mynow>
         <myamount> #Mutez(Amount) </myamount>
         <tokenAddress> _TokenAddress:Address </tokenAddress>
-        <paramtype> %default |-> #Type(#LiquidityBakingParamType()) </paramtype>
+        <paramtype> _LocalEntrypoints </paramtype>
      requires notBool Amount ==Int 0
          orBool notBool CurrentTime <Int Deadline
 endmodule
@@ -347,12 +352,13 @@ module LIQUIDITY-BAKING-TOKENTOXTZ-NEGATIVE-2-SPEC
         <tokenAddress> TokenAddress:Address </tokenAddress>
         <xtzPool> #Mutez(_XtzPool) </xtzPool>
         <tokenPool> TokenPool </tokenPool>
-        <paramtype> %default |-> #Type(#LiquidityBakingParamType()) </paramtype>
+        <paramtype> LocalEntrypoints </paramtype>
      requires notBool Amount ==Int 0
       andBool notBool CurrentTime <Int Deadline
       andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer, #TokenTransferType())
       andBool #EntrypointExists(KnownAddresses, To,           %default,  #Type(unit))
       andBool #EntrypointExists(KnownAddresses, null_address, %default,  #Type(unit))
+      andBool #LocalEntrypoints(LocalEntrypoints, %default, unit)
       andBool notBool (TokenPool >Int 0 orBool TokensSold >Int 0)
 endmodule
 ```
@@ -367,12 +373,13 @@ module LIQUIDITY-BAKING-TOKENTOXTZ-NEGATIVE-3-SPEC
         <tokenAddress> TokenAddress:Address </tokenAddress>
         <xtzPool> #Mutez(XtzPool) </xtzPool>
         <tokenPool> TokenPool </tokenPool>
-        <paramtype> %default |-> #Type(#LiquidityBakingParamType()) </paramtype>
+        <paramtype> LocalEntrypoints </paramtype>
      requires notBool Amount ==Int 0
       andBool notBool CurrentTime <Int Deadline
       andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer, #TokenTransferType())
       andBool #EntrypointExists(KnownAddresses, To,           %default,  #Type(unit))
       andBool #EntrypointExists(KnownAddresses, null_address, %default,  #Type(unit))
+      andBool #LocalEntrypoints(LocalEntrypoints, %default, unit)
       andBool notBool( #XtzBought(XtzPool, TokenPool, TokensSold) >=Int  MinXtzBought
                andBool #IsLegalMutezValue(MinXtzBought)
                      )
@@ -389,12 +396,13 @@ module LIQUIDITY-BAKING-TOKENTOXTZ-NEGATIVE-4-SPEC
         <tokenAddress> TokenAddress:Address </tokenAddress>
         <xtzPool> #Mutez(XtzPool) </xtzPool>
         <tokenPool> TokenPool </tokenPool>
-        <paramtype> %default |-> #Type(#LiquidityBakingParamType()) </paramtype>
+        <paramtype> LocalEntrypoints </paramtype>
      requires notBool Amount ==Int 0
       andBool notBool CurrentTime <Int Deadline
       andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer, #TokenTransferType())
       andBool #EntrypointExists(KnownAddresses, To,           %default,  #Type(unit))
       andBool #EntrypointExists(KnownAddresses, null_address, %default,  #Type(unit))
+      andBool #LocalEntrypoints(LocalEntrypoints, %default, unit)
       andBool  #XtzBought(XtzPool, TokenPool, TokensSold) >=Int  MinXtzBought
       andBool #IsLegalMutezValue(MinXtzBought)
       andBool notBool( #XtzBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
@@ -417,7 +425,7 @@ module LIQUIDITY-BAKING-XTZTOTOKEN-POSITIVE-SPEC
   imports LIQUIDITY-BAKING-VERIFICATION
   claim <k> #runProof(XtzToToken(To, MinTokensBought, #Timestamp(Deadline))) => . </k>
         <stack> .Stack </stack>
-        <paramtype> %default |-> #Type(#LiquidityBakingParamType()) </paramtype>
+        <paramtype> LocalEntrypoints </paramtype>
         <myamount> #Mutez(Amount) </myamount>
         <tokenAddress> TokenAddress </tokenAddress>
         <xtzPool> #Mutez(XtzPool => XtzPool +Int Amount) </xtzPool>
@@ -440,6 +448,7 @@ module LIQUIDITY-BAKING-XTZTOTOKEN-POSITIVE-SPEC
 
      andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer, #TokenTransferType())
      andBool #EntrypointExists(KnownAddresses, null_address, %default,  #Type(unit))
+     andBool #LocalEntrypoints(LocalEntrypoints, %default, unit)
 endmodule
 ```
 
@@ -448,7 +457,7 @@ module LIQUIDITY-BAKING-XTZTOTOKEN-NEGATIVE-SPEC
   imports LIQUIDITY-BAKING-VERIFICATION
   claim <k> #runProof(XtzToToken(_To, MinTokensBought, #Timestamp(Deadline))) => Aborted(?_, ?_, ?_, ?_) </k>
         <stack> .Stack => ?_:FailedStack </stack>
-        <paramtype> %default |-> #Type(#LiquidityBakingParamType()) </paramtype>
+        <paramtype> LocalEntrypoints </paramtype>
         <myamount> #Mutez(Amount) </myamount>
         <tokenAddress> TokenAddress </tokenAddress>
         <xtzPool> #Mutez(XtzPool) </xtzPool>
@@ -465,6 +474,7 @@ module LIQUIDITY-BAKING-XTZTOTOKEN-NEGATIVE-SPEC
                      )
      andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer, #TokenTransferType())
      andBool #EntrypointExists(KnownAddresses, null_address, %default,  #Type(unit))
+     andBool #LocalEntrypoints(LocalEntrypoints, %default, unit)
 endmodule
 ```
 
@@ -493,7 +503,7 @@ A buyer sends tokens to the Liquidity Baking contract, converts its to xtz, and 
         <mynow> #Timestamp(CurrentTime) </mynow>
         <senderaddr> Sender </senderaddr>
         <myaddr> SelfAddress </myaddr>
-        <paramtype> %default |-> #Type(#LiquidityBakingParamType()) </paramtype>
+        <paramtype> LocalEntrypoints </paramtype>
         <nonce> #Nonce(N => N +Int 3) </nonce>
         <knownaddrs> KnownAddresses </knownaddrs>
         <operations> _
@@ -510,6 +520,7 @@ A buyer sends tokens to the Liquidity Baking contract, converts its to xtz, and 
       andBool #EntrypointExists(KnownAddresses, TokenAddress,         %transfer,   #TokenTransferType())
       andBool #EntrypointExists(KnownAddresses, OutputDexterContract, %xtzToToken, pair (address %to) (pair (nat %minTokensBought) (timestamp %deadline)))
       andBool #EntrypointExists(KnownAddresses, null_address,         %default,    #Type(unit))
+      andBool #LocalEntrypoints(LocalEntrypoints, %default, unit)
 ```
 
 ```k
@@ -533,7 +544,7 @@ module LIQUIDITY-BAKING-TOKENTOTOKEN-NEGATIVE-SPEC
         <mynow> #Timestamp(CurrentTime) </mynow>
         <senderaddr> _Sender </senderaddr>
         <myaddr> _SelfAddress </myaddr>
-        <paramtype> %default |-> #Type(#LiquidityBakingParamType()) </paramtype>
+        <paramtype> LocalEntrypoints </paramtype>
         <nonce> #Nonce(_N => ?_) </nonce>
         <knownaddrs> KnownAddresses </knownaddrs>
         <operations> _ </operations>
@@ -546,6 +557,7 @@ module LIQUIDITY-BAKING-TOKENTOTOKEN-NEGATIVE-SPEC
       andBool #EntrypointExists(KnownAddresses, TokenAddress,         %transfer,   #TokenTransferType())
       andBool #EntrypointExists(KnownAddresses, OutputDexterContract, %xtzToToken, pair (address %to) (pair (nat %minTokensBought) (timestamp %deadline)))
       andBool #EntrypointExists(KnownAddresses, null_address,         %default,    #Type(unit))
+      andBool #LocalEntrypoints(LocalEntrypoints, %default, unit)
 ```
 
 ```k

--- a/tests/proofs/liquidity-baking/lb.md
+++ b/tests/proofs/liquidity-baking/lb.md
@@ -443,6 +443,13 @@ and so we can't have simplification rules for both.
   syntax Int ::= #XtzBurn(Int)
  // --------------------------
   rule #XtzBurn(Amount) => Amount:Int -Int #mulDiv ( Amount:Int , 999 , 1000 ) [macro]
+
+  syntax Bool ::= #LocalEntrypointExists(Map, FieldAnnotation, Type)
+ // ----------------------------------------------------------------
+  rule #LocalEntrypointExists(LocalEntrypoints, FieldAnnot, EntrypointType)
+    => FieldAnnot in_keys(LocalEntrypoints) andBool
+       LocalEntrypoints[FieldAnnot] ==K #Name(EntrypointType)
+    [macro]
 ```
 
 ### Avoiding Interpreting Functions

--- a/tests/proofs/liquidity-baking/lb.md
+++ b/tests/proofs/liquidity-baking/lb.md
@@ -439,6 +439,12 @@ and so we can't have simplification rules for both.
     [macro]
 ```
 
+```k
+  syntax Int ::= #XtzBurn(Int)
+ // --------------------------
+  rule #XtzBurn(Amount) => Amount:Int -Int #mulDiv ( Amount:Int , 999 , 1000 ) [macro]
+```
+
 ### Avoiding Interpreting Functions
 
 If a function value does not play well with the prover or SMT solver, it can be rewritten to `#uninterpreted`.
@@ -450,10 +456,6 @@ This function has no evaluation rules, so the prover can make no assumptions abo
  // -----------------------------------------------------------------------------------------
   rule (X *Int Y) %Int Z => #mulMod(X, Y, Z) [simplification]
   rule (X *Int Y) /Int Z => #mulDiv(X, Y, Z) [simplification]
-
-  syntax Int ::= #XtzBurn(Int) [function, functional, smtlib(xtxBurn), no-evaluators]
- // ---------------------------------------------------------------------------------
-  rule Amount:Int -Int #mulDiv ( Amount:Int , 999 , 1000 ) => #XtzBurn(Amount) [simplification]
 ```
 
 ## Putting It All Together

--- a/tests/proofs/liquidity-baking/lb.md
+++ b/tests/proofs/liquidity-baking/lb.md
@@ -432,10 +432,10 @@ and so we can't have simplification rules for both.
 
 ```k
   syntax Bool ::= #EntrypointExists(Map, Address, FieldAnnotation, Type)
-// --------------------------------------------------------------------
-  rule #EntrypointExists(KnownAddresses, Addr, _FieldAnnot, EntrypointType)
-    => Addr in_keys(KnownAddresses) andBool
-       KnownAddresses[Addr] ==K #Contract(Addr, EntrypointType)
+ // --------------------------------------------------------------------
+  rule #EntrypointExists(KnownAddresses, Addr, FieldAnnot, EntrypointType)
+    => Addr . FieldAnnot  in_keys(KnownAddresses) andBool
+       KnownAddresses[Addr . FieldAnnot] ==K #Name(EntrypointType)
     [macro]
 ```
 
@@ -451,9 +451,9 @@ This function has no evaluation rules, so the prover can make no assumptions abo
   rule (X *Int Y) %Int Z => #mulMod(X, Y, Z) [simplification]
   rule (X *Int Y) /Int Z => #mulDiv(X, Y, Z) [simplification]
 
-  // TODO: add #XtzBurn smt-lib symbol
-  // syntax Int ::= #XtzBurn(Int)
-  // rule Amount:Int -Int #mulDiv ( Amount:Int , 999 , 1000 ) => #XtzBurn(Amount)
+  syntax Int ::= #XtzBurn(Int) [function, functional, smtlib(xtxBurn), no-evaluators]
+ // ---------------------------------------------------------------------------------
+  rule Amount:Int -Int #mulDiv ( Amount:Int , 999 , 1000 ) => #XtzBurn(Amount) [simplification]
 ```
 
 ## Putting It All Together


### PR DESCRIPTION
Updates include:

- fix entrypoint syntax
- add `#XtzBurn` macro for representing burn fee calculations
- add missing burn txns for conversion entrypoints
- add kast script for lb specs and `kmich` support
- mark unused variables to quiet warnings

EDIT: In my history, this is on top of #308, but technically, they don't depend on each other at all, so this could be merged first, if that would be more helpful. I am hopeful that, after this latest round of fixes, the updated Dexter specs should pass.