### PR TITLE
Add Liquidity Baking `tokenToXtz` spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -427,10 +427,7 @@ dexter_spec_modules = DEXTER-SPEC                               \
                       DEXTER-SETBAKER-SPEC                      \
                       DEXTER-SETLQTADDRESS-SPEC                 \
                       DEXTER-SETMANAGER-SPEC                    \
-                      DEXTER-TOKENTOXTZ-FA12-NEGATIVE-1-SPEC    \
-                      DEXTER-TOKENTOXTZ-FA12-NEGATIVE-2-SPEC    \
-                      DEXTER-TOKENTOXTZ-FA12-NEGATIVE-3-SPEC    \
-                      DEXTER-TOKENTOXTZ-FA12-NEGATIVE-4-SPEC    \
+                      DEXTER-TOKENTOXTZ-FA12-NEGATIVE-SPEC    \
                       DEXTER-TOKENTOXTZ-FA12-POSITIVE-SPEC      \
                       DEXTER-TOKENTOXTZ-FA2-NEGATIVE-1-SPEC     \
                       DEXTER-TOKENTOXTZ-FA2-NEGATIVE-2-SPEC     \

--- a/tests/proofs/liquidity-baking/lb-spec.md
+++ b/tests/proofs/liquidity-baking/lb-spec.md
@@ -322,7 +322,6 @@ even though the final mutez value that is actually used is smaller than or equal
       andBool CurrentTime <Int Deadline
       andBool (TokenPool >Int 0 orBool TokensSold >Int 0)
 
-      andBool #IsLegalMutezValue(MinXtzBought)
       andBool #IsLegalMutezValue(#CurrencyBought(XtzPool, TokenPool, TokensSold))
       andBool #IsLegalMutezValue(#CurrencyBought(XtzPool, TokenPool, TokensSold) *Int 999)
       andBool #IsLegalMutezValue(#XtzNetBurn(#CurrencyBought(XtzPool, TokenPool, TokensSold)))
@@ -342,104 +341,30 @@ endmodule
 The following claims prove the negative case:
 
 ```k
-module LIQUIDITY-BAKING-TOKENTOXTZ-NEGATIVE-1-SPEC
+module LIQUIDITY-BAKING-TOKENTOXTZ-NEGATIVE-SPEC
   imports LIQUIDITY-BAKING-VERIFICATION
   claim <k> #runProof(TokenToXtz(To, _TokensSold, #Mutez(_MinXtzBought), #Timestamp(Deadline))) => Aborted(?_, ?_, ?_, ?_) </k>
         <stack> .Stack => ?_:FailedStack </stack>
         <mynow> #Timestamp(CurrentTime) </mynow>
         <myamount> #Mutez(Amount) </myamount>
-        <tokenAddress> TokenAddress:Address </tokenAddress>
+        <nonce> #Nonce(_ => ?_) </nonce>
         <paramtype> LocalEntrypoints </paramtype>
         <knownaddrs> KnownAddresses </knownaddrs>
-     requires notBool ( Amount ==Int 0
-                andBool CurrentTime <Int Deadline
-                      )
 
-      andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer, #TokenTransferType())
-      andBool #EntrypointExists(KnownAddresses, To,           %default,  #Type(unit))
-      andBool #EntrypointExists(KnownAddresses, null_address, %default,  #Type(unit))
-      andBool #LocalEntrypointExists(LocalEntrypoints, %default, unit)
-endmodule
-```
-
-```k
-module LIQUIDITY-BAKING-TOKENTOXTZ-NEGATIVE-2-SPEC
-  imports LIQUIDITY-BAKING-VERIFICATION
-  claim <k> #runProof(TokenToXtz(To, TokensSold, #Mutez(_MinXtzBought), #Timestamp(Deadline))) => Aborted(?_, ?_, ?_, ?_) </k>
-        <stack> .Stack => ?_:FailedStack </stack>
-        <mynow> #Timestamp(CurrentTime) </mynow>
-        <myamount> #Mutez(Amount) </myamount>
         <tokenAddress> TokenAddress:Address </tokenAddress>
         <xtzPool> #Mutez(_XtzPool) </xtzPool>
         <tokenPool> TokenPool </tokenPool>
-        <paramtype> LocalEntrypoints </paramtype>
-        <knownaddrs> KnownAddresses </knownaddrs>
-     requires Amount ==Int 0
-      andBool CurrentTime <Int Deadline
-      andBool TokenPool ==Int 0 andBool TokensSold ==Int 0
+     requires notBool ( Amount ==Int 0
+                andBool (TokenPool >Int 0 orBool TokensSold >Int 0)
+                andBool #IsLegalMutezValue(#CurrencyBought(XtzPool, TokenPool, TokensSold))
+                andBool #IsLegalMutezValue(#CurrencyBought(XtzPool, TokenPool, TokensSold) *Int 999)
+                andBool #IsLegalMutezValue(#XtzNetBurn(#CurrencyBought(XtzPool, TokenPool, TokensSold)))
+                andBool #XtzNetBurn(#CurrencyBought(XtzPool, TokenPool, TokensSold)) >=Int MinXtzBought
 
-      andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer, #TokenTransferType())
-      andBool #EntrypointExists(KnownAddresses, To,           %default,  #Type(unit))
-      andBool #EntrypointExists(KnownAddresses, null_address, %default,  #Type(unit))
-      andBool #LocalEntrypointExists(LocalEntrypoints, %default, unit)
-endmodule
-```
-
-```k
-module LIQUIDITY-BAKING-TOKENTOXTZ-NEGATIVE-3-SPEC
-  imports LIQUIDITY-BAKING-VERIFICATION
-  claim <k> #runProof(TokenToXtz(To, TokensSold, #Mutez(MinXtzBought), #Timestamp(Deadline))) => Aborted(?_, ?_, ?_, ?_) </k>
-        <stack> .Stack => ?_:FailedStack </stack>
-        <mynow> #Timestamp(CurrentTime) </mynow>
-        <myamount> #Mutez(Amount) </myamount>
-        <tokenAddress> TokenAddress:Address </tokenAddress>
-        <xtzPool> #Mutez(XtzPool) </xtzPool>
-        <tokenPool> TokenPool </tokenPool>
-        <paramtype> LocalEntrypoints </paramtype>
-        <knownaddrs> KnownAddresses </knownaddrs>
-        <nonce> #Nonce(_ => ?_) </nonce>
-     requires Amount ==Int 0
-      andBool CurrentTime <Int Deadline
-      andBool ( TokenPool >Int 0 orBool TokensSold >Int 0 )
-      andBool notBool( #IsLegalMutezValue(MinXtzBought)
-               andBool #IsLegalMutezValue(#CurrencyBought(XtzPool, TokenPool, TokensSold))
-               andBool #IsLegalMutezValue(#CurrencyBought(XtzPool, TokenPool, TokensSold) *Int 999)
-               andBool #IsLegalMutezValue(#XtzNetBurn(#CurrencyBought(XtzPool, TokenPool, TokensSold)))
-               andBool #XtzNetBurn(#CurrencyBought(XtzPool, TokenPool, TokensSold)) >=Int MinXtzBought
-                     )
-
-      andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer, #TokenTransferType())
-      andBool #EntrypointExists(KnownAddresses, To,           %default,  #Type(unit))
-      andBool #EntrypointExists(KnownAddresses, null_address, %default,  #Type(unit))
-      andBool #LocalEntrypointExists(LocalEntrypoints, %default, unit)
-endmodule
-```
-
-```k
-module LIQUIDITY-BAKING-TOKENTOXTZ-NEGATIVE-4-SPEC
-  imports LIQUIDITY-BAKING-VERIFICATION
-  claim <k> #runProof(TokenToXtz(To, TokensSold, #Mutez(MinXtzBought), #Timestamp(Deadline))) => Aborted(?_, ?_, ?_, ?_) </k>
-        <stack> .Stack => ?_:FailedStack </stack>
-        <mynow> #Timestamp(CurrentTime) </mynow>
-        <myamount> #Mutez(Amount) </myamount>
-        <tokenAddress> TokenAddress:Address </tokenAddress>
-        <xtzPool> #Mutez(XtzPool) </xtzPool>
-        <tokenPool> TokenPool </tokenPool>
-        <paramtype> LocalEntrypoints </paramtype>
-        <knownaddrs> KnownAddresses </knownaddrs>
-        <nonce> #Nonce(_ => ?_) </nonce>
-     requires Amount ==Int 0
-      andBool CurrentTime <Int Deadline
-      andBool ( TokenPool >Int 0 orBool TokensSold >Int 0 )
-      andBool #IsLegalMutezValue(MinXtzBought)
-      andBool #IsLegalMutezValue(#CurrencyBought(XtzPool, TokenPool, TokensSold))
-      andBool #IsLegalMutezValue(#CurrencyBought(XtzPool, TokenPool, TokensSold) *Int 999)
-      andBool #IsLegalMutezValue(#XtzNetBurn(#CurrencyBought(XtzPool, TokenPool, TokensSold)))
-      andBool #XtzNetBurn(#CurrencyBought(XtzPool, TokenPool, TokensSold)) >=Int MinXtzBought
-      andBool notBool( #IsLegalMutezValue(#XtzBurnAmount(#CurrencyBought(XtzPool, TokenPool, TokensSold)))
-               andBool #CurrencyBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
-               andBool #IsLegalMutezValue(XtzPool -Int #CurrencyBought(XtzPool, TokenPool, TokensSold))
-                     )
+                andBool #IsLegalMutezValue(#XtzBurnAmount(#CurrencyBought(XtzPool, TokenPool, TokensSold)))
+                andBool #CurrencyBought(XtzPool, TokenPool, TokensSold) <=Int XtzPool
+                andBool #IsLegalMutezValue(XtzPool -Int #CurrencyBought(XtzPool, TokenPool, TokensSold))
+                      )
 
       andBool #EntrypointExists(KnownAddresses, TokenAddress, %transfer, #TokenTransferType())
       andBool #EntrypointExists(KnownAddresses, To,           %default,  #Type(unit))

--- a/tests/proofs/liquidity-baking/lb.md
+++ b/tests/proofs/liquidity-baking/lb.md
@@ -412,22 +412,19 @@ If the contract execution fails, storage is not updated.
   rule #ceildivAux(X, Y) => X /Int Y          requires Y  =/=Int 0 andBool         X %Int Y ==Int 0
   rule #ceildivAux(X, Y) => X /Int Y +Int 1   requires Y  =/=Int 0 andBool notBool X %Int Y ==Int 0
 
-  syntax Int ::= #XtzBought   (Int, Int, Int) [function, functional, smtlib(xtzbought), no-evaluators]
- // --------------------------------------------------------------------------------------------------
-  rule (TokensSold *Int 999 *Int XtzPool) /Int (TokenPool *Int 1000 +Int (TokensSold *Int 999))
-    => #XtzBought(XtzPool, TokenPool, TokensSold)
+  syntax Int ::= #CurrencyBought(Int, Int, Int) [function, functional, smtlib(xtzbought), no-evaluators]
+ // ----------------------------------------------------------------------------------------------------
+  rule (ToSellAmt *Int 999 *Int ToBuyCurrencyTotal) /Int (ToSellCurrencyTotal *Int 1000 +Int (ToSellAmt *Int 999))
+    => #CurrencyBought(ToBuyCurrencyTotal, ToSellCurrencyTotal, ToSellAmt)
     [simplification]
-```
 
-We'd like to additionally define `#TokensBought`, however this has the same structure as `#XtzBought`
-and so we can't have simplification rules for both.
+  syntax Int ::= #XtzNetBurn(Int)
+ // -----------------------------
+  rule #XtzNetBurn(XtzAmount) => #mulDiv( XtzAmount , 999 , 1000 ) [macro]
 
-```k
- // syntax Int ::= #TokensBought(Int, Int, Int) [function, functional, smtlib(tokensbought), no-evaluators]
- // -------------------------------------------------------------------------------------------------------
- // rule (Amount *Int 999 *Int TokenPool) /Int (XtzPool *Int 1000 +Int (Amount *Int 999))
- //   => #TokensBought(XtzPool, TokenPool, XtzSold)
- //   [simplification]
+  syntax Int ::= #XtzBurnAmount(Int)
+ // --------------------------------
+  rule #XtzBurnAmount(XtzAmount) => XtzAmount -Int #XtzNetBurn ( XtzAmount ) [macro]
 ```
 
 ```k
@@ -437,12 +434,6 @@ and so we can't have simplification rules for both.
     => Addr . FieldAnnot  in_keys(KnownAddresses) andBool
        KnownAddresses[Addr . FieldAnnot] ==K #Name(EntrypointType)
     [macro]
-```
-
-```k
-  syntax Int ::= #XtzBurn(Int)
- // --------------------------
-  rule #XtzBurn(Amount) => Amount:Int -Int #mulDiv ( Amount:Int , 999 , 1000 ) [macro]
 
   syntax Bool ::= #LocalEntrypointExists(Map, FieldAnnotation, Type)
  // ----------------------------------------------------------------


### PR DESCRIPTION
Reopened version of #309 

@sskeirik I've pushed another commit that combines the negative cases. We shouldnt need multiple negative cases since we were able to fix the flakiness issue. The new combined negative case uses the negation of the positive case's side conditions as its side condition. This does not go through, implying that the side condition of the positive case is too tight (or possibly that some additional axioms are needed).
