### PR TITLE
Update Tezos to v10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ FROM runtimeverificationinc/kframework-k:ubuntu-focal-${K_COMMIT}
 RUN    apt-get update                \
     && apt-get upgrade --yes         \
     && apt-get install --yes         \
-                cargo                \
                 cmake                \
                 curl                 \
                 jq                   \

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,8 @@ RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.11 \
     && cd ../..                                                      \
     && rm -rf z3
 
+RUN curl -sL https://sh.rustup.rs | bash -
+
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN    apt-get update               \
     && apt-get upgrade --yes        \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ RUN    apt-get update                \
                 pkg-config           \
                 python3              \
                 python3-pip          \
-                python-pygments      \
                 python3-recommonmark \
+                python-pygments      \
                 sphinx-common        \
                 zlib1g-dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM runtimeverificationinc/kframework-k:ubuntu-focal-${K_COMMIT}
 RUN    apt-get update                \
     && apt-get upgrade --yes         \
     && apt-get install --yes         \
+                autoconf             \
                 cmake                \
                 curl                 \
                 jq                   \
@@ -23,7 +24,8 @@ RUN    apt-get update                \
                 python3-pip          \
                 python-pygments      \
                 python3-recommonmark \
-                sphinx-common
+                sphinx-common        \
+                zlib1g-dev
 
 RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.11 \
     && cd z3                                                         \
@@ -33,8 +35,6 @@ RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.11 \
     && make install                                                  \
     && cd ../..                                                      \
     && rm -rf z3
-
-RUN curl -sL https://sh.rustup.rs/rustup-init.sh | bash -s -- --profile minimal --default-toolchain 1.52.1 -y
 
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN    apt-get update               \
@@ -49,6 +49,9 @@ RUN groupadd -g $GROUP_ID user && useradd -m -u $USER_ID -s /bin/sh -g user user
 
 USER user:user
 WORKDIR /home/user
+
+RUN    curl -sL https://sh.rustup.rs/rustup-init.sh | bash -s -- --profile minimal --default-toolchain 1.52.1 -y \
+    && echo 'source $HOME/.cargo/env' >> $HOME/.bashrc
 
 RUN    git config --global user.email 'admin@runtimeverification.com' \
     && git config --global user.name  'RV Jenkins'                    \

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,9 @@ RUN groupadd -g $GROUP_ID user && useradd -m -u $USER_ID -s /bin/sh -g user user
 USER user:user
 WORKDIR /home/user
 
-RUN    curl -sL https://sh.rustup.rs/rustup-init.sh | bash -s -- --profile minimal --default-toolchain 1.52.1 -y \
-    && echo 'source $HOME/.cargo/env' >> $HOME/.bashrc
+# setup rust with correct version
+RUN curl -sL https://sh.rustup.rs/rustup-init.sh | bash -s -- --profile minimal --default-toolchain 1.52.1 -y
+ENV PATH="/home/user/.cargo/bin/:${PATH}"
 
 RUN    git config --global user.email 'admin@runtimeverification.com' \
     && git config --global user.name  'RV Jenkins'                    \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN    apt-get update                \
     && apt-get install --yes         \
                 cargo                \
                 cmake                \
+                curl                 \
                 jq                   \
                 libcrypto++-dev      \
                 libev-dev            \
@@ -34,7 +35,7 @@ RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.11 \
     && cd ../..                                                      \
     && rm -rf z3
 
-RUN curl -sL https://sh.rustup.rs | bash -
+RUN curl -sL https://sh.rustup.rs/rustup-init.sh | bash -s -- --profile minimal --default-toolchain 1.52.1 -y
 
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN    apt-get update               \

--- a/Makefile
+++ b/Makefile
@@ -107,8 +107,8 @@ SOURCE_FILES       := compat    \
 EXTRA_SOURCE_FILES :=
 ALL_FILES          := $(patsubst %, %.md, $(SOURCE_FILES) $(EXTRA_SOURCE_FILES))
 
-tangle_haskell := k | symbolic
-tangle_llvm    := k | concrete
+tangle_haskell := k|symbolic
+tangle_llvm    := k|concrete
 
 HOOK_NAMESPACES := TIME
 
@@ -255,7 +255,7 @@ driver_pattern_parser := $(driver_dir)/$(notdir $(driver_main_file))-kompiled/pa
 defn-driver:  $(driver_files)
 build-driver: $(driver_kompiled) $(driver_pattern_parser)
 
-$(driver_kompiled): tangle_haskell := k | driver
+$(driver_kompiled): tangle_haskell := k|driver
 $(driver_kompiled): $(driver_files)
 	$(KOMPILE_LLVM) $(driver_main_file).md                  \
 	                --directory $(driver_dir) -I $(CURDIR)  \
@@ -277,7 +277,7 @@ symbolic_kompiled      := $(symbolic_dir)/$(notdir $(symbolic_main_file))-kompil
 defn-symbolic:  $(symbolic_files)
 build-symbolic: $(symbolic_kompiled) build-driver
 
-$(symbolic_kompiled): tangle_haskell := k | symbolic | internalized-rl
+$(symbolic_kompiled): tangle_haskell := k|symbolic|internalized-rl
 $(symbolic_kompiled): $(symbolic_files)
 	$(KOMPILE_HASKELL) $(symbolic_main_file).md                  \
 	                   --directory $(symbolic_dir) -I $(CURDIR)  \

--- a/Makefile
+++ b/Makefile
@@ -131,15 +131,15 @@ ifeq (,$(RELEASE))
 endif
 
 KOMPILE_LLVM = "kompile" --debug --backend llvm --md-selector "$(tangle_llvm)" \
-               --hook-namespaces "$(HOOK_NAMESPACES)"                        \
-               $(KOMPILE_OPTS)                                               \
-               $(KOMPILE_KRUN_OPTS)                                          \
+               --hook-namespaces "$(HOOK_NAMESPACES)"                          \
+               $(KOMPILE_OPTS)                                                 \
+               $(KOMPILE_KRUN_OPTS)                                            \
                $(addprefix -ccopt ,$(LLVM_KOMPILE_OPTS))
 
 HASKELL_KOMPILE_OPTS +=
 
 KOMPILE_HASKELL = "kompile" --debug --backend haskell --md-selector "$(tangle_haskell)" \
-                  $(KOMPILE_OPTS)                                                     \
+                  $(KOMPILE_OPTS)                                                       \
                   $(HASKELL_KOMPILE_OPTS)
 
 defn:        defn-k defn-compat

--- a/Makefile
+++ b/Makefile
@@ -122,8 +122,7 @@ endif
 
 CPP_FILES := hooks/time.cpp
 
-LLVM_KOMPILE_OPTS += --hook-namespaces "$(HOOK_NAMESPACES)"      \
-                     -L$(LOCAL_LIB) -I$(K_RELEASE)/include/kllvm \
+LLVM_KOMPILE_OPTS += -L$(LOCAL_LIB) -I$(K_RELEASE)/include/kllvm \
                      $(abspath $(CPP_FILES))                     \
                      -std=c++14
 
@@ -132,6 +131,7 @@ ifeq (,$(RELEASE))
 endif
 
 KOMPILE_LLVM = kompile --debug --backend llvm --md-selector "$(tangle_llvm)" \
+               --hook-namespaces "$(HOOK_NAMESPACES)"                        \
                $(KOMPILE_OPTS)                                               \
                $(KOMPILE_KRUN_OPTS)                                          \
                $(addprefix -ccopt ,$(LLVM_KOMPILE_OPTS))

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,8 @@ tangle_llvm    := k | concrete
 HOOK_NAMESPACES := TIME
 
 # NOTE: -W useless-rule check is quite expensive (increasing compilation times by several times), use -Wno useless-rule unless this check is needed!!!
-KOMPILE_OPTS += --hook-namespaces "$(HOOK_NAMESPACES)" --gen-bison-parser --emit-json -w all -Wno unused-symbol -Wno useless-rule
+KOMPILE_OPTS += -w all -Wno unused-symbol -Wno useless-rule
+KOMPILE_KRUN_OPTS += --gen-bison-parser
 
 ifneq (,$(RELEASE))
     KOMPILE_OPTS += -O3
@@ -121,7 +122,8 @@ endif
 
 CPP_FILES := hooks/time.cpp
 
-LLVM_KOMPILE_OPTS += -L$(LOCAL_LIB) -I$(K_RELEASE)/include/kllvm \
+LLVM_KOMPILE_OPTS += --hook-namespaces "$(HOOK_NAMESPACES)"      \
+                     -L$(LOCAL_LIB) -I$(K_RELEASE)/include/kllvm \
                      $(abspath $(CPP_FILES))                     \
                      -std=c++14
 
@@ -131,6 +133,7 @@ endif
 
 KOMPILE_LLVM = kompile --debug --backend llvm --md-selector "$(tangle_llvm)" \
                $(KOMPILE_OPTS)                                               \
+               $(KOMPILE_KRUN_OPTS)                                          \
                $(addprefix -ccopt ,$(LLVM_KOMPILE_OPTS))
 
 HASKELL_KOMPILE_OPTS +=

--- a/Makefile
+++ b/Makefile
@@ -282,7 +282,8 @@ $(symbolic_kompiled): $(symbolic_files)
 	$(KOMPILE_HASKELL) $(symbolic_main_file).md                  \
 	                   --directory $(symbolic_dir) -I $(CURDIR)  \
 	                   --main-module $(symbolic_main_module)     \
-	                   --syntax-module $(symbolic_syntax_module)
+	                   --syntax-module $(symbolic_syntax_module) \
+	                   $(KOMPILE_KRUN_OPTS)
 
 # Compat Contract Expander
 

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ ifeq (,$(RELEASE))
     LLVM_KOMPILE_OPTS += -g
 endif
 
-KOMPILE_LLVM = kompile --debug --backend llvm --md-selector "$(tangle_llvm)" \
+KOMPILE_LLVM = "kompile" --debug --backend llvm --md-selector "$(tangle_llvm)" \
                --hook-namespaces "$(HOOK_NAMESPACES)"                        \
                $(KOMPILE_OPTS)                                               \
                $(KOMPILE_KRUN_OPTS)                                          \
@@ -138,7 +138,7 @@ KOMPILE_LLVM = kompile --debug --backend llvm --md-selector "$(tangle_llvm)" \
 
 HASKELL_KOMPILE_OPTS +=
 
-KOMPILE_HASKELL = kompile --debug --backend haskell --md-selector "$(tangle_haskell)" \
+KOMPILE_HASKELL = "kompile" --debug --backend haskell --md-selector "$(tangle_haskell)" \
                   $(KOMPILE_OPTS)                                                     \
                   $(HASKELL_KOMPILE_OPTS)
 
@@ -263,7 +263,7 @@ $(driver_kompiled): $(driver_files)
 	                --syntax-module $(driver_syntax_module)
 
 $(driver_pattern_parser): $(driver_files) $(driver_kompiled)
-	kast --gen-parser --directory $(driver_dir) --sort Pattern $@
+	"kast" --gen-parser --directory $(driver_dir) --sort Pattern $@
 
 ### Symbolic
 

--- a/common.md
+++ b/common.md
@@ -36,7 +36,7 @@ to contracts with entrypoints. We may fix this issue in a later release.
   rule #Name(T:UnaryTypeName _:AnnotationList ArgT) => T #Name(ArgT)
   rule #Name(T:BinaryTypeName _:AnnotationList ArgT1 ArgT2) => T #Name(ArgT1) #Name(ArgT2)
   rule #Name(T:BinaryPlusTypeName _:AnnotationList ArgT1 ArgT2:Type) => T #Name(ArgT1) #Name(ArgT2)
-  rule #Name(T:BinaryPlusTypeName _:AnnotationList ArgT1 ArgT2:Type ArgT3:TypeList) => T #Name(ArgT1) #Name(T .AnnotationList ArgT2 ArgT3)
+  rule #Name(T:BinaryPlusTypeName _:AnnotationList ArgT1 ArgT2:Type ArgT3:NeTypeList) => T #Name(ArgT1) #Name(T .AnnotationList ArgT2 ArgT3)
 
   syntax Type ::= #Type(TypeName) [function, functional]
   // ---------------------------------------------------
@@ -492,17 +492,17 @@ We recursively convert the contents of pairs, ors and options, if applicable.
        Pair #MichelineToNative(A, T1, KnownAddrs, BigMaps) #MichelineToNative(B, T2, KnownAddrs, BigMaps)
 
   // type pun
-  rule #MichelineToNative(Pair A (Pair B C), pair Annots T1:Type T2:Type T3:TypeList, KnownAddrs, BigMaps) =>
+  rule #MichelineToNative(Pair A (Pair B C), pair Annots T1:Type T2:Type T3:NeTypeList, KnownAddrs, BigMaps) =>
        Pair #MichelineToNative(A,        T1,                 KnownAddrs, BigMaps)
             #MichelineToNative(Pair B C, pair Annots T2 T3,  KnownAddrs, BigMaps)
 
   // data pun
-  rule #MichelineToNative(Pair A B:Data C:PairDataList, pair _ T1:Type (pair Annots T2:Type T3:Type), KnownAddrs, BigMaps) =>
+  rule #MichelineToNative(Pair A B:Data C:NePairDataList, pair _ T1:Type (pair Annots T2:Type T3:Type), KnownAddrs, BigMaps) =>
        Pair #MichelineToNative(A,         T1,                 KnownAddrs, BigMaps)
             #MichelineToNative(Pair B C, (pair Annots T2 T3), KnownAddrs, BigMaps)
 
   // type and data pun
-  rule #MichelineToNative(Pair A B:Data C:PairDataList, pair Annots T1:Type T2:Type T3:TypeList, KnownAddrs, BigMaps) =>
+  rule #MichelineToNative(Pair A B:Data C:NePairDataList, pair Annots T1:Type T2:Type T3:NeTypeList, KnownAddrs, BigMaps) =>
        Pair #MichelineToNative(A,         T1,                 KnownAddrs, BigMaps)
             #MichelineToNative(Pair B C, (pair Annots T2 T3), KnownAddrs, BigMaps)
 

--- a/compat.md
+++ b/compat.md
@@ -64,12 +64,16 @@ module MICHELSON-UNPARSER
     " " +String
     #doUnparse(AL, false)
 
-
-  rule #doUnparse(Pair D1 D2, false) =>
+  rule #doUnparse(Pair D1 DL:PairDataList, false) =>
     "Pair " +String
     #doUnparse(D1, true) +String
     " " +String
-    #doUnparse(D2, true)
+    #doUnparse(DL, true)
+
+  rule #doUnparse(D1:Data DL:PairDataList, true) =>
+    #doUnparse(D1, true) +String
+    " " +String
+    #doUnparse(DL, true)
 
   rule #doUnparse(Left D, false) => "Left " +String #doUnparse(D, true)
   rule #doUnparse(Right D, false) => "Right " +String #doUnparse(D, true)
@@ -177,6 +181,18 @@ module MICHELSON-UNPARSER
 
   rule #doUnparse(TyName:BinaryTypeName AL:AnnotationList T1 T2, true) =>
     "(" +String #doUnparse(TyName AL T1 T2, false) +String ")"
+
+  rule #doUnparse(TyName:BinaryPlusTypeName AL:AnnotationList T1:Type TL:TypeList, false) =>
+    #doUnparse(TyName, false) +String
+    " " +String
+    #doUnparse(AL, false) +String
+    " " +String
+    #doUnparse(T1 TL, true)
+
+  rule #doUnparse(TyName:BinaryPlusTypeName AL:AnnotationList T1:Type TL:TypeList, true) =>
+    "(" +String #doUnparse(TyName AL T1 TL, false) +String ")"
+
+  rule #doUnparse(T1:Type TL:TypeList, B:Bool) => #doUnparse(T1, B) +String " " +String #doUnparse(TL, B)
 
   rule #doUnparse(DROP AList, _) => "DROP" +String #doUnparse(AList, false)
   rule #doUnparse(DROP AList I:Int, _) => "DROP" +String #doUnparse(AList, false) +String " " +String #doUnparse(I, true)

--- a/compat.md
+++ b/compat.md
@@ -64,13 +64,13 @@ module MICHELSON-UNPARSER
     " " +String
     #doUnparse(AL, false)
 
-  rule #doUnparse(Pair D1 DL:PairDataList, false) =>
+  rule #doUnparse(Pair D1 DL:NePairDataList, false) =>
     "Pair " +String
     #doUnparse(D1, true) +String
     " " +String
     #doUnparse(DL, true)
 
-  rule #doUnparse(D1:Data DL:PairDataList, true) =>
+  rule #doUnparse(D1:Data DL:NePairDataList, true) =>
     #doUnparse(D1, true) +String
     " " +String
     #doUnparse(DL, true)
@@ -182,17 +182,17 @@ module MICHELSON-UNPARSER
   rule #doUnparse(TyName:BinaryTypeName AL:AnnotationList T1 T2, true) =>
     "(" +String #doUnparse(TyName AL T1 T2, false) +String ")"
 
-  rule #doUnparse(TyName:BinaryPlusTypeName AL:AnnotationList T1:Type TL:TypeList, false) =>
+  rule #doUnparse(TyName:BinaryPlusTypeName AL:AnnotationList T1:Type TL:NeTypeList, false) =>
     #doUnparse(TyName, false) +String
     " " +String
     #doUnparse(AL, false) +String
     " " +String
     #doUnparse(T1 TL, true)
 
-  rule #doUnparse(TyName:BinaryPlusTypeName AL:AnnotationList T1:Type TL:TypeList, true) =>
+  rule #doUnparse(TyName:BinaryPlusTypeName AL:AnnotationList T1:Type TL:NeTypeList, true) =>
     "(" +String #doUnparse(TyName AL T1 TL, false) +String ")"
 
-  rule #doUnparse(T1:Type TL:TypeList, B:Bool) => #doUnparse(T1, B) +String " " +String #doUnparse(TL, B)
+  rule #doUnparse(T1:Type TL:NeTypeList, B:Bool) => #doUnparse(T1, B) +String " " +String #doUnparse(TL, B)
 
   rule #doUnparse(DROP AList, _) => "DROP" +String #doUnparse(AList, false)
   rule #doUnparse(DROP AList I:Int, _) => "DROP" +String #doUnparse(AList, false) +String " " +String #doUnparse(I, true)

--- a/lib/combine.py
+++ b/lib/combine.py
@@ -1,6 +1,12 @@
 from sys import argv
+
+def add_parens(typestr):
+    if len(typestr.strip().split()) > 1:
+        return "(" + typestr + ")"
+    return typestr
+
 with open(argv[1], 'r') as types_file, open(argv[2], 'r') as data_file:
     types = types_file.readlines()[1:]
     data = data_file.readlines()[1:]
     assert len(types) == len(data)
-    print("real_output {{ {0} }} ;".format(" ; ".join(["Stack_elt {0} {1}".format(type_[:-1].strip(), data[:-1].strip()) for (type_, data) in zip(types, data)])))
+    print("real_output {{ {0} }} ;".format(" ; ".join(["Stack_elt {0} {1}".format(add_parens(type_[:-1]), data[:-1].strip()) for (type_, data) in zip(types, data)])))

--- a/michelson.md
+++ b/michelson.md
@@ -327,7 +327,7 @@ The following unit test groups are not supported by the symbolic interpreter.
 
   rule #ConvertBigMapsToNative(.Map) => .Map
   rule #ConvertBigMapsToNative(I |-> #BigMap(D, T) BigMaps)
-   => I |-> #MichelineToNative(D, T, .Map, .Map) #ConvertBigMapsToNative(BigMaps)
+   => (I |-> #MichelineToNative(D, T, .Map, .Map))::Map #ConvertBigMapsToNative(BigMaps)
 ```
 
 ```k
@@ -1180,7 +1180,7 @@ The `#DoCompare` function requires additional lemmas for symbolic execution.
   syntax String ::= #ConcatStrings(InternalList, String) [function]
   // --------------------------------------------------------------
   rule #ConcatStrings(.InternalList, A) => A
-  rule #ConcatStrings([ S1 ] ;; DL,  A) => #ConcatStrings(DL, A +String S1)
+  rule #ConcatStrings([| S1 |] ;; DL,  A) => #ConcatStrings(DL, A +String S1)
 ```
 
 The actual out of bounds conditions here are determined by experimentation.
@@ -1234,7 +1234,7 @@ distinguish this case from lists of strings.
   syntax Bytes ::= #ConcatBytes(InternalList, Bytes) [function]
   // ----------------------------------------------------------
   rule #ConcatBytes(.InternalList, A) => A
-  rule #ConcatBytes([ B ] ;; DL,   A) => #ConcatBytes(DL, A +Bytes B)
+  rule #ConcatBytes([| B |] ;; DL,   A) => #ConcatBytes(DL, A +Bytes B)
 ```
 
 `SIZE` is relatively simple, except that we must remember to divide by two,

--- a/michelson.md
+++ b/michelson.md
@@ -1531,7 +1531,7 @@ since it does not need to track the new map while keeping it off the stack.
 
 ```k
   rule <k> CONS _A => .  ... </k>
-       <stack> [T V] ; [list T L] ; SS => [list T [ V ] ;; L] ; SS </stack>
+       <stack> [T V] ; [list T L] ; SS => [list T [| V |] ;; L] ; SS </stack>
 
   rule <k> NIL _A T => .  ... </k>
        <stack> SS => [list #Name(T) .InternalList] ; SS </stack>
@@ -1541,7 +1541,7 @@ since it does not need to track the new map while keeping it off the stack.
         ~> BT
            ...
        </k>
-       <stack> [list T [ E ] ;; L] ; SS => [T E] ; [list T L] ; SS </stack>
+       <stack> [list T [| E |] ;; L] ; SS => [T E] ; [list T L] ; SS </stack>
 
   rule <k> IF_CONS _A _  BF => BF ... </k>
        <stack> [list _ .InternalList ] ; SS => SS </stack>
@@ -1559,7 +1559,7 @@ since it does not need to track the new map while keeping it off the stack.
         ~> ITER .AnnotationList Body
            ...
        </k>
-       <stack> [list T [ E ] ;; L] ; SS => [T E] ; SS </stack>
+       <stack> [list T [| E |] ;; L] ; SS => [T E] ; SS </stack>
 ```
 
 The `MAP` operation over `list`s is defined in terms of a helper function.
@@ -1577,7 +1577,7 @@ The `MAP` operation over `list`s is defined in terms of a helper function.
   rule <k> #DoMap(T, NT, .InternalList, Acc, _) => .K ... </k>
        <stack> SS => [list #DefaultType(NT,T) #ReverseList(Acc, .InternalList)] ; SS </stack>
 
-  rule <k> #DoMap(T, NT, [ E ] ;; L, Acc, B)
+  rule <k> #DoMap(T, NT, [| E |] ;; L, Acc, B)
         => B
         ~> #DoMapAux(T, NT, L, Acc, B)
            ...
@@ -1585,7 +1585,7 @@ The `MAP` operation over `list`s is defined in terms of a helper function.
        <stack> SS => [T E] ; SS </stack>
 
   rule <k> #DoMapAux(T, NT, L, Acc, B)
-        => #DoMap(T, NT', L, [ E ] ;; Acc, B)
+        => #DoMap(T, NT', L, [| E |] ;; Acc, B)
            ...
        </k>
        <stack> [NT' E] ; SS => SS </stack>

--- a/pretty-syntax.md
+++ b/pretty-syntax.md
@@ -220,7 +220,7 @@ We get around this problem by explicitly declaring every `NullaryTypeName` a `Ty
 
   rule N:UnaryTypeName      T     => N .AnnotationList T
   rule N:BinaryTypeName     T1 T2 => N .AnnotationList T1 T2
-  rule N:BinaryPlusTypeName T TL => N .AnnotationList T TL
+  rule N:BinaryPlusTypeName T TL  => N .AnnotationList T TL
 ```
 
 ## Literals

--- a/pretty-syntax.md
+++ b/pretty-syntax.md
@@ -216,9 +216,11 @@ We get around this problem by explicitly declaring every `NullaryTypeName` a `Ty
 ```k
   syntax Type ::= UnaryTypeName   Type [macro]
                 | BinaryTypeName  Type Type [macro]
+                | BinaryPlusTypeName Type TypeList [macro]
 
-  rule N:UnaryTypeName  T     => N .AnnotationList T
-  rule N:BinaryTypeName T1 T2 => N .AnnotationList T1 T2
+  rule N:UnaryTypeName      T     => N .AnnotationList T
+  rule N:BinaryTypeName     T1 T2 => N .AnnotationList T1 T2
+  rule N:BinaryPlusTypeName T1 TL => N .AnnotationList T1 TL
 ```
 
 ## Literals

--- a/pretty-syntax.md
+++ b/pretty-syntax.md
@@ -220,7 +220,7 @@ We get around this problem by explicitly declaring every `NullaryTypeName` a `Ty
 
   rule N:UnaryTypeName      T     => N .AnnotationList T
   rule N:BinaryTypeName     T1 T2 => N .AnnotationList T1 T2
-  rule N:BinaryPlusTypeName T1 TL => N .AnnotationList T1 TL
+  rule N:BinaryPlusTypeName T TL => N .AnnotationList T TL
 ```
 
 ## Literals

--- a/pretty-syntax.md
+++ b/pretty-syntax.md
@@ -216,7 +216,7 @@ We get around this problem by explicitly declaring every `NullaryTypeName` a `Ty
 ```k
   syntax Type ::= UnaryTypeName   Type [macro]
                 | BinaryTypeName  Type Type [macro]
-                | BinaryPlusTypeName Type TypeList [macro]
+                | BinaryPlusTypeName Type NeTypeList [macro]
 
   rule N:UnaryTypeName      T     => N .AnnotationList T
   rule N:BinaryTypeName     T1 T2 => N .AnnotationList T1 T2

--- a/syntax.md
+++ b/syntax.md
@@ -146,8 +146,8 @@ Simple recursive data structures are defined as expected.
 
 ```k
   syntax Pair           ::= "Pair" Data NePairDataList
-  syntax NePairDataList ::= Data NePairDataList
-                          > Data
+  syntax NePairDataList ::= Data NePairDataList [avoid]
+                          | Data
 
   syntax OrData ::= "Left" Data
                   | "Right" Data

--- a/syntax.md
+++ b/syntax.md
@@ -85,14 +85,19 @@ Types are defined as expected.
 
   syntax MapTypeName ::= "map" | "big_map"
 
-  syntax BinaryTypeName  ::= "pair"
-                           | "or"
+  syntax BinaryTypeName  ::= "or"
                            | "lambda"
                            | MapTypeName
 
-  syntax Type ::= NullaryTypeName AnnotationList
-                | UnaryTypeName   AnnotationList Type
-                | BinaryTypeName  AnnotationList Type Type
+  syntax BinaryPlusTypeName ::= "pair"
+
+  syntax Type ::= NullaryTypeName    AnnotationList
+                | UnaryTypeName      AnnotationList Type
+                | BinaryTypeName     AnnotationList Type Type
+                | BinaryPlusTypeName AnnotationList Type TypeList
+
+  syntax TypeList ::= Type TypeList
+                    | Type
 ```
 
 ### Data Literal Syntax
@@ -140,7 +145,9 @@ At parse time, `mutez` and `address` literals are read in as ints and strings.
 Simple recursive data structures are defined as expected.
 
 ```k
-  syntax Pair ::= "Pair" Data Data
+  syntax Pair         ::= "Pair" Data PairDataList
+  syntax PairDataList ::= Data PairDataList [avoid]
+                        | Data
 
   syntax OrData ::= "Left" Data
                   | "Right" Data

--- a/syntax.md
+++ b/syntax.md
@@ -94,10 +94,10 @@ Types are defined as expected.
   syntax Type ::= NullaryTypeName    AnnotationList
                 | UnaryTypeName      AnnotationList Type
                 | BinaryTypeName     AnnotationList Type Type
-                | BinaryPlusTypeName AnnotationList Type TypeList
+                | BinaryPlusTypeName AnnotationList Type NeTypeList
 
-  syntax TypeList ::= Type
-                    > Type TypeList
+  syntax NeTypeList ::= Type
+                      > Type NeTypeList
 ```
 
 ### Data Literal Syntax
@@ -145,9 +145,9 @@ At parse time, `mutez` and `address` literals are read in as ints and strings.
 Simple recursive data structures are defined as expected.
 
 ```k
-  syntax Pair         ::= "Pair" Data PairDataList
-  syntax PairDataList ::= Data PairDataList [avoid]
-                        | Data
+  syntax Pair           ::= "Pair" Data NePairDataList
+  syntax NePairDataList ::= Data NePairDataList
+                          > Data
 
   syntax OrData ::= "Left" Data
                   | "Right" Data

--- a/syntax.md
+++ b/syntax.md
@@ -96,8 +96,8 @@ Types are defined as expected.
                 | BinaryTypeName     AnnotationList Type Type
                 | BinaryPlusTypeName AnnotationList Type TypeList
 
-  syntax TypeList ::= Type TypeList
-                    | Type
+  syntax TypeList ::= Type
+                    > Type TypeList
 ```
 
 ### Data Literal Syntax

--- a/tests/failing.cross
+++ b/tests/failing.cross
@@ -45,6 +45,8 @@ tests/unit/self_02.tzt
 tests/unit/self_03.tzt
 tests/unit/split_ticket_00.tzt
 tests/unit/split_ticket_01.tzt
+tests/unit/sub_timestamp-int_03.tzt
+tests/unit/sub_timestamp-int_04.tzt
 
 tests/macros/pair_00.tzt
 tests/macros/unpair_00.tzt

--- a/tests/proofs/dexter/dexter-spec.md
+++ b/tests/proofs/dexter/dexter-spec.md
@@ -82,8 +82,8 @@ We have one case for when `#ceildiv` results in an upwards rounding, and one for
         <knownaddrs> KnownAddresses </knownaddrs>
         <paramtype> LocalEntrypoints </paramtype>
         <operations> _
-                  => [ Transfer_tokens #TokenTransferData(IsFA2, Sender, SelfAddress, TokenId, #ceildiv(Amount *Int TokenAmount, XtzAmount)) #Mutez(0) TokenAddress . %transfer Nonce ] ;;
-                     [ Transfer_tokens Pair ((Amount *Int OldLqt) /Int XtzAmount) Owner #Mutez(0) LqtAddress . %mintOrBurn (Nonce +Int 1) ] ;;
+                  => [| Transfer_tokens #TokenTransferData(IsFA2, Sender, SelfAddress, TokenId, #ceildiv(Amount *Int TokenAmount, XtzAmount)) #Mutez(0) TokenAddress . %transfer Nonce |] ;;
+                     [| Transfer_tokens Pair ((Amount *Int OldLqt) /Int XtzAmount) Owner #Mutez(0) LqtAddress . %mintOrBurn (Nonce +Int 1) |] ;;
                      .InternalList
         </operations>
     requires CurrentTime <Int Deadline
@@ -117,8 +117,8 @@ We have one case for when `#ceildiv` results in an upwards rounding, and one for
         <knownaddrs> KnownAddresses </knownaddrs>
         <paramtype> LocalEntrypoints </paramtype>
         <operations> _
-                  => [ Transfer_tokens #TokenTransferData(IsFA2, Sender, SelfAddress, TokenId, #ceildiv(Amount *Int TokenAmount, XtzAmount)) #Mutez(0) TokenAddress . %transfer Nonce ] ;;
-                     [ Transfer_tokens Pair ((Amount *Int OldLqt) /Int XtzAmount) Owner #Mutez(0) LqtAddress . %mintOrBurn (Nonce +Int 1) ] ;;
+                  => [| Transfer_tokens #TokenTransferData(IsFA2, Sender, SelfAddress, TokenId, #ceildiv(Amount *Int TokenAmount, XtzAmount)) #Mutez(0) TokenAddress . %transfer Nonce |] ;;
+                     [| Transfer_tokens Pair ((Amount *Int OldLqt) /Int XtzAmount) Owner #Mutez(0) LqtAddress . %mintOrBurn (Nonce +Int 1) |] ;;
                      .InternalList
         </operations>
     requires notBool IsUpdating
@@ -229,9 +229,9 @@ module DEXTER-REMOVELIQUIDITY-POSITIVE-SPEC
         <knownaddrs> KnownAddresses </knownaddrs>
         <paramtype> LocalEntrypoints </paramtype> // 1027
         <operations> _
-                  => [ Transfer_tokens (Pair (0 -Int LqtBurned) Sender) #Mutez(0) LqtAddress . %mintOrBurn Nonce ] ;;
-                     [ Transfer_tokens #TokenTransferData(IsFA2, SelfAddress, To, TokenId,  (LqtBurned *Int TokenAmount) /Int OldLqt) #Mutez(0) TokenAddress . %transfer (Nonce +Int 1) ] ;;
-                     [ Transfer_tokens Unit #Mutez((LqtBurned *Int XtzAmount) /Int OldLqt) To . %default (Nonce +Int 2) ] ;;
+                  => [| Transfer_tokens (Pair (0 -Int LqtBurned) Sender) #Mutez(0) LqtAddress . %mintOrBurn Nonce |] ;;
+                     [| Transfer_tokens #TokenTransferData(IsFA2, SelfAddress, To, TokenId,  (LqtBurned *Int TokenAmount) /Int OldLqt) #Mutez(0) TokenAddress . %transfer (Nonce +Int 1) |] ;;
+                     [| Transfer_tokens Unit #Mutez((LqtBurned *Int XtzAmount) /Int OldLqt) To . %default (Nonce +Int 2) |] ;;
                      .InternalList
         </operations>
     requires CurrentTime <Int Deadline
@@ -352,7 +352,7 @@ The contract sets its delegate to the value of `baker` (and optionally freezes t
         <senderaddr> Sender </senderaddr>
         <freezeBaker> false => NewFreezeBaker </freezeBaker>
         <nonce> #Nonce(N => N +Int 1) </nonce>
-        <operations> _ => [ Set_delegate Baker N:Int ] ;; .InternalList </operations>
+        <operations> _ => [| Set_delegate Baker N:Int |] ;; .InternalList </operations>
     requires Amount ==Int 0
 ```
 
@@ -453,7 +453,7 @@ The contract queries its underlying token contract for its own token balance if 
         <sourceaddr> Sender </sourceaddr>
         <paramtype> LocalEntrypoints </paramtype>
         <knownaddrs> KnownAddresses </knownaddrs>
-        <operations> _ => [ Transfer_tokens Pair #UpdateTokenPoolTransferFrom(IsFA2, SelfAddress, TokenId) #Contract(SelfAddress . %updateTokenPoolInternal, #DexterVersionSpecificParamType(IsFA2)) #Mutez(0) #TokenBalanceEntrypoint(TokenAddress, IsFA2) O ] ;; .InternalList </operations>
+        <operations> _ => [| Transfer_tokens Pair #UpdateTokenPoolTransferFrom(IsFA2, SelfAddress, TokenId) #Contract(SelfAddress . %updateTokenPoolInternal, #DexterVersionSpecificParamType(IsFA2)) #Mutez(0) #TokenBalanceEntrypoint(TokenAddress, IsFA2) O |] ;; .InternalList </operations>
         <nonce> #Nonce(O) => #Nonce(O +Int 1) </nonce>
     requires Amount ==Int 0
      andBool #EntrypointExists(KnownAddresses, TokenAddress, #if IsFA2 #then %balance_of #else %getBalance #fi, #TokenBalanceEntrypointType(IsFA2))
@@ -551,7 +551,7 @@ Summary: The underlying token contract updates the Dexter contract's view of its
 In the FA2, UpdateTokenPoolInternal ignores all balances additional balances passed in:
 
 ```k
-  claim <k> #runProof(true, UpdateTokenPoolInternalFA2([ Pair Pair _ _ Balance ] ;; _BalanceOfResultRest)) => . </k>
+  claim <k> #runProof(true, UpdateTokenPoolInternalFA2([| Pair Pair _ _ Balance |] ;; _BalanceOfResultRest)) => . </k>
         <stack> .Stack </stack>
         <selfIsUpdatingTokenPool> true => false </selfIsUpdatingTokenPool>
         <myamount> #Mutez(0) </myamount>
@@ -701,8 +701,8 @@ A buyer sends tokens to the Dexter contract and receives a corresponding amount 
         <knownaddrs> KnownAddresses </knownaddrs>
         <tokenId> TokenID </tokenId>
         <operations> _
-                  => [ Transfer_tokens #TokenTransferData(IsFA2, Sender, SelfAddress, TokenID, TokensSold) #Mutez(0)                                               TokenAddress . %transfer N        ]
-                  ;; [ Transfer_tokens Unit                                                                #Mutez(#CurrencyBought(XtzPool, TokenPool, TokensSold)) To           . %default (N +Int 1)]
+                  => [| Transfer_tokens #TokenTransferData(IsFA2, Sender, SelfAddress, TokenID, TokensSold) #Mutez(0)                                               TokenAddress . %transfer N        |]
+                  ;; [| Transfer_tokens Unit                                                                #Mutez(#CurrencyBought(XtzPool, TokenPool, TokensSold)) To           . %default (N +Int 1)|]
                   ;; .InternalList
         </operations>
      requires notBool IsFA2
@@ -853,8 +853,8 @@ As before, a buyer sends tokens to the Dexter contract and receives a correspond
         <knownaddrs> KnownAddresses </knownaddrs>
         <tokenId> TokenID </tokenId>
         <operations> _
-                  => [ Transfer_tokens #TokenTransferData(IsFA2, Sender, SelfAddress, TokenID, TokensSold) #Mutez(0)                                               TokenAddress . %transfer N        ]
-                  ;; [ Transfer_tokens Unit                                                                #Mutez(#CurrencyBought(XtzPool, TokenPool, TokensSold)) To           . %default (N +Int 1)]
+                  => [| Transfer_tokens #TokenTransferData(IsFA2, Sender, SelfAddress, TokenID, TokensSold) #Mutez(0)                                               TokenAddress . %transfer N        |]
+                  ;; [| Transfer_tokens Unit                                                                #Mutez(#CurrencyBought(XtzPool, TokenPool, TokensSold)) To           . %default (N +Int 1)|]
                   ;; .InternalList
         </operations>
      requires IsFA2
@@ -990,7 +990,7 @@ module DEXTER-XTZTOTOKEN-FA12-POSITIVE-SPEC
         <tokenId> TokenID </tokenId>
         <knownaddrs> KnownAddresses </knownaddrs>
         <operations> _
-                  => [ Transfer_tokens #TokenTransferData(IsFA2, SelfAddress, To, TokenID, #CurrencyBought(TokenPool, XtzPool, Amount)) #Mutez(0) TokenAddress . %transfer N ]
+                  => [| Transfer_tokens #TokenTransferData(IsFA2, SelfAddress, To, TokenID, #CurrencyBought(TokenPool, XtzPool, Amount)) #Mutez(0) TokenAddress . %transfer N |]
                   ;; .InternalList
         </operations>
     requires notBool IsFA2
@@ -1054,7 +1054,7 @@ module DEXTER-XTZTOTOKEN-FA2-POSITIVE-SPEC
         <tokenId> TokenID </tokenId>
         <knownaddrs> KnownAddresses </knownaddrs>
         <operations> _
-                  => [ Transfer_tokens #TokenTransferData(IsFA2, SelfAddress, To, TokenID, #CurrencyBought(TokenPool, XtzPool, Amount)) #Mutez(0) TokenAddress . %transfer N ]
+                  => [| Transfer_tokens #TokenTransferData(IsFA2, SelfAddress, To, TokenID, #CurrencyBought(TokenPool, XtzPool, Amount)) #Mutez(0) TokenAddress . %transfer N |]
                   ;; .InternalList
         </operations>
     requires IsFA2
@@ -1133,8 +1133,8 @@ A buyer sends tokens to the Dexter contract, converts its to xtz, and then immed
         <tokenId> TokenID </tokenId>
         <knownaddrs> KnownAddresses </knownaddrs>
         <operations> _
-                  => [ Transfer_tokens #TokenTransferData(IsFA2, Sender, SelfAddress, TokenID, TokensSold) #Mutez(0)                                               TokenAddress         . %transfer    N        ]
-                  ;; [ Transfer_tokens Pair To Pair MinTokensBought #Timestamp(Deadline)                   #Mutez(#CurrencyBought(XtzPool, TokenPool, TokensSold)) OutputDexterContract . %xtzToToken (N +Int 1)]
+                  => [| Transfer_tokens #TokenTransferData(IsFA2, Sender, SelfAddress, TokenID, TokensSold) #Mutez(0)                                               TokenAddress         . %transfer    N        |]
+                  ;; [| Transfer_tokens Pair To Pair MinTokensBought #Timestamp(Deadline)                   #Mutez(#CurrencyBought(XtzPool, TokenPool, TokensSold)) OutputDexterContract . %xtzToToken (N +Int 1)|]
                   ;; .InternalList
         </operations>
      requires notBool IsFA2
@@ -1166,8 +1166,8 @@ A buyer sends tokens to the Dexter contract, converts its to xtz, and then immed
         <tokenId> TokenID </tokenId>
         <knownaddrs> KnownAddresses </knownaddrs>
         <operations> _
-                  => [ Transfer_tokens #TokenTransferData(IsFA2, Sender, SelfAddress, TokenID, TokensSold) #Mutez(0)                                               TokenAddress         . %transfer    N        ]
-                  ;; [ Transfer_tokens Pair To Pair MinTokensBought #Timestamp(Deadline)                   #Mutez(#CurrencyBought(XtzPool, TokenPool, TokensSold)) OutputDexterContract . %xtzToToken (N +Int 1)]
+                  => [| Transfer_tokens #TokenTransferData(IsFA2, Sender, SelfAddress, TokenID, TokensSold) #Mutez(0)                                               TokenAddress         . %transfer    N        |]
+                  ;; [| Transfer_tokens Pair To Pair MinTokensBought #Timestamp(Deadline)                   #Mutez(#CurrencyBought(XtzPool, TokenPool, TokensSold)) OutputDexterContract . %xtzToToken (N +Int 1)|]
                   ;; .InternalList
         </operations>
      requires IsFA2

--- a/tests/proofs/dexter/dexter.md
+++ b/tests/proofs/dexter/dexter.md
@@ -267,7 +267,7 @@ Each entrypoint is given a unique abstract parameter type that we use to simplif
                           | validBalanceOfEntry(Data)          [function, functional]
             // ----------------------------------------------------------
             rule validBalanceOfParams(.InternalList) => true
-            rule validBalanceOfParams([ D:Data ] ;; IL:InternalList)
+            rule validBalanceOfParams([| D:Data |] ;; IL:InternalList)
               => validBalanceOfEntry(D) andBool validBalanceOfParams(IL)
 
             rule validBalanceOfEntry(Pair (Pair _:Address N1:Int) N2:Int)
@@ -562,8 +562,8 @@ If the contract execution fails, storage is not updated.
 ```k
   syntax Data ::= #UpdateTokenPoolTransferFrom(Bool, Address, Int) [function, functional]
  // -------------------------------------------------------------------------------------
-  rule #UpdateTokenPoolTransferFrom(IsFA2, SelfAddress, _TokenId) =>        SelfAddress                            requires notBool IsFA2 [simplification]
-  rule #UpdateTokenPoolTransferFrom(IsFA2, SelfAddress,  TokenId) => [ Pair SelfAddress TokenId ] ;; .InternalList requires         IsFA2 [simplification]
+  rule #UpdateTokenPoolTransferFrom(IsFA2, SelfAddress, _TokenId) =>         SelfAddress                             requires notBool IsFA2 [simplification]
+  rule #UpdateTokenPoolTransferFrom(IsFA2, SelfAddress,  TokenId) => [| Pair SelfAddress TokenId |] ;; .InternalList requires         IsFA2 [simplification]
 
   syntax Type ::= #TokenContractType(Bool) [function, functional]
  // -------------------------------------------------------------
@@ -577,8 +577,8 @@ If the contract execution fails, storage is not updated.
 
   syntax Data ::= #TokenTransferData(Bool, Address, Address, Int, Int) [function, functional]
  // -----------------------------------------------------------------------------------------
-  rule #TokenTransferData(false, From, To, _TokenID, TokenAmt) =>   Pair From    Pair To              TokenAmt [simplification]
-  rule #TokenTransferData(true,  From, To,  TokenID, TokenAmt) => [ Pair From ([ Pair To Pair TokenID TokenAmt ] ;; .InternalList)  ] ;; .InternalList [simplification]
+  rule #TokenTransferData(false, From, To, _TokenID, TokenAmt) =>    Pair From     Pair To              TokenAmt                                          [simplification]
+  rule #TokenTransferData(true,  From, To,  TokenID, TokenAmt) => [| Pair From ([| Pair To Pair TokenID TokenAmt |] ;; .InternalList) |] ;; .InternalList [simplification]
 
   syntax Entrypoint ::= #TokenBalanceEntrypoint(Address, Bool) [function, functional]
  // ---------------------------------------------------------------------------------

--- a/tests/proofs/liquidity-baking/lb-spec.md
+++ b/tests/proofs/liquidity-baking/lb-spec.md
@@ -73,8 +73,8 @@ We have one case for when `#ceildiv` results in an upwards rounding, and one for
         <knownaddrs> KnownAddresses </knownaddrs>
         <paramtype> LocalEntrypoints </paramtype>
         <operations> _
-                  => [ Transfer_tokens #TokenTransferData(Sender, SelfAddress, #ceildiv(Amount *Int TokenAmount, XtzAmount)) #Mutez(0) TokenAddress . %transfer    Nonce ] ;;
-                     [ Transfer_tokens Pair ((Amount *Int OldLqt) /Int XtzAmount) Owner                                      #Mutez(0) LqtAddress   . %mintOrBurn (Nonce +Int 1) ] ;;
+                  => [| Transfer_tokens #TokenTransferData(Sender, SelfAddress, #ceildiv(Amount *Int TokenAmount, XtzAmount)) #Mutez(0) TokenAddress . %transfer    Nonce         |] ;;
+                     [| Transfer_tokens Pair ((Amount *Int OldLqt) /Int XtzAmount) Owner                                      #Mutez(0) LqtAddress   . %mintOrBurn (Nonce +Int 1) |] ;;
                      .InternalList
         </operations>
     requires CurrentTime <Int Deadline
@@ -158,9 +158,9 @@ module LIQUIDITY-BAKING-REMOVELIQUIDITY-POSITIVE-SPEC
         <knownaddrs> KnownAddresses </knownaddrs>
         <paramtype> LocalEntrypoints </paramtype>
         <operations> _
-                  => [ Transfer_tokens (Pair (0 -Int LqtBurned) Sender)                                              #Mutez(0)                                      LqtAddress . %mintOrBurn  Nonce         ] ;;
-                     [ Transfer_tokens #TokenTransferData(SelfAddress, To, (LqtBurned *Int TokenAmount) /Int OldLqt) #Mutez(0)                                      TokenAddress . %transfer (Nonce +Int 1) ] ;;
-                     [ Transfer_tokens Unit                                                                          #Mutez((LqtBurned *Int XtzAmount) /Int OldLqt) To . %default            (Nonce +Int 2) ] ;;
+                  => [| Transfer_tokens (Pair (0 -Int LqtBurned) Sender)                                              #Mutez(0)                                      LqtAddress . %mintOrBurn  Nonce         |] ;;
+                     [| Transfer_tokens #TokenTransferData(SelfAddress, To, (LqtBurned *Int TokenAmount) /Int OldLqt) #Mutez(0)                                      TokenAddress . %transfer (Nonce +Int 1) |] ;;
+                     [| Transfer_tokens Unit                                                                          #Mutez((LqtBurned *Int XtzAmount) /Int OldLqt) To . %default            (Nonce +Int 2) |] ;;
                      .InternalList
         </operations>
     requires CurrentTime <Int Deadline
@@ -287,9 +287,9 @@ even though the final mutez value that is actually used is smaller than or equal
         <nonce> #Nonce(N => N +Int 3) </nonce>
         <knownaddrs> KnownAddresses </knownaddrs>
         <operations> _
-                  => [ Transfer_tokens #TokenTransferData(Sender, SelfAddress, TokensSold) #Mutez(0)                                                               TokenAddress . %transfer N        ]
-                  ;; [ Transfer_tokens Unit                                                #Mutez(#XtzNetBurn(#CurrencyBought(XtzPool, TokenPool, TokensSold)))    To           . %default (N +Int 1)]
-                  ;; [ Transfer_tokens Unit                                                #Mutez(#XtzBurnAmount(#CurrencyBought(XtzPool, TokenPool, TokensSold))) null_address . %default (N +Int 2)]
+                  => [| Transfer_tokens #TokenTransferData(Sender, SelfAddress, TokensSold) #Mutez(0)                                                               TokenAddress . %transfer N        |]
+                  ;; [| Transfer_tokens Unit                                                #Mutez(#XtzNetBurn(#CurrencyBought(XtzPool, TokenPool, TokensSold)))    To           . %default (N +Int 1)|]
+                  ;; [| Transfer_tokens Unit                                                #Mutez(#XtzBurnAmount(#CurrencyBought(XtzPool, TokenPool, TokensSold))) null_address . %default (N +Int 2)|]
                   ;; .InternalList
         </operations>
      requires Amount ==Int 0
@@ -445,8 +445,8 @@ module LIQUIDITY-BAKING-XTZTOTOKEN-POSITIVE-SPEC
         <nonce> #Nonce(N => N +Int 2) </nonce>
         <knownaddrs> KnownAddresses </knownaddrs>
         <operations> _
-                  => [ Transfer_tokens #TokenTransferData(SelfAddress, To, #CurrencyBought(TokenPool, XtzPool, #XtzNetBurn(Amount))) #Mutez(0)                              TokenAddress . %transfer N        ]
-                  ;; [ Transfer_tokens Unit                                                                                          #Mutez(absInt(#XtzBurnAmount(Amount))) null_address . %default (N +Int 1)]
+                  => [| Transfer_tokens #TokenTransferData(SelfAddress, To, #CurrencyBought(TokenPool, XtzPool, #XtzNetBurn(Amount))) #Mutez(0)                              TokenAddress . %transfer N        |]
+                  ;; [| Transfer_tokens Unit                                                                                          #Mutez(absInt(#XtzBurnAmount(Amount))) null_address . %default (N +Int 1)|]
                   ;; .InternalList
         </operations>
     requires CurrentTime <Int Deadline
@@ -523,9 +523,9 @@ A buyer sends tokens to the Liquidity Baking contract, converts its to xtz, and 
         <nonce> #Nonce(N => N +Int 3) </nonce>
         <knownaddrs> KnownAddresses </knownaddrs>
         <operations> _
-                  => [ Transfer_tokens #TokenTransferData(Sender, SelfAddress, TokensSold) #Mutez(0)                                                               TokenAddress         . %transfer    N        ]
-                  ;; [ Transfer_tokens Pair To Pair MinTokensBought #Timestamp(Deadline)   #Mutez(#XtzNetBurn(#CurrencyBought(XtzPool, TokenPool, TokensSold)))    OutputDexterContract . %xtzToToken (N +Int 1)]
-                  ;; [ Transfer_tokens Unit                                                #Mutez(#XtzBurnAmount(#CurrencyBought(XtzPool, TokenPool, TokensSold))) null_address         . %default    (N +Int 2)]
+                  => [| Transfer_tokens #TokenTransferData(Sender, SelfAddress, TokensSold) #Mutez(0)                                                               TokenAddress         . %transfer    N        |]
+                  ;; [| Transfer_tokens Pair To Pair MinTokensBought #Timestamp(Deadline)   #Mutez(#XtzNetBurn(#CurrencyBought(XtzPool, TokenPool, TokensSold)))    OutputDexterContract . %xtzToToken (N +Int 1)|]
+                  ;; [| Transfer_tokens Unit                                                #Mutez(#XtzBurnAmount(#CurrencyBought(XtzPool, TokenPool, TokensSold))) null_address         . %default    (N +Int 2)|]
                   ;; .InternalList
         </operations>
      requires Amount ==Int 0

--- a/tests/proofs/lqt/lqt-spec.md
+++ b/tests/proofs/lqt/lqt-spec.md
@@ -25,7 +25,7 @@ module LQT-TOKEN-GETTOTALSUPPLY-SPEC
         <stack> .Stack </stack>
         <totalSupply> TotalSupply </totalSupply>
         <nonce> #Nonce(Nonce => Nonce +Int 1) </nonce>
-        <operations> _ => [ Transfer_tokens TotalSupply #Mutez(0) Callback (Nonce) ] ;; .InternalList </operations>
+        <operations> _ => [| Transfer_tokens TotalSupply #Mutez(0) Callback (Nonce) |] ;; .InternalList </operations>
         <myamount> #Mutez(Amount) </myamount>
     requires Amount ==Int 0
 
@@ -44,7 +44,7 @@ module LQT-TOKEN-GETBALANCE-SPEC
         <stack> .Stack </stack>
         <tokens> Tokens </tokens>
         <nonce> #Nonce(Nonce => Nonce +Int 1) </nonce>
-        <operations> _ => [ Transfer_tokens {Tokens[Address]}:>Int #Mutez(0) Callback (Nonce) ] ;; .InternalList </operations>
+        <operations> _ => [| Transfer_tokens {Tokens[Address]}:>Int #Mutez(0) Callback (Nonce) |] ;; .InternalList </operations>
         <myamount> #Mutez(Amount) </myamount>
     requires Amount ==Int 0
      andBool Address in_keys(Tokens)
@@ -53,7 +53,7 @@ module LQT-TOKEN-GETBALANCE-SPEC
         <stack> .Stack </stack>
         <tokens> Tokens </tokens>
         <nonce> #Nonce(Nonce => Nonce +Int 1) </nonce>
-        <operations> _ => [ Transfer_tokens 0 #Mutez(0) Callback (Nonce) ] ;; .InternalList </operations>
+        <operations> _ => [| Transfer_tokens 0 #Mutez(0) Callback (Nonce) |] ;; .InternalList </operations>
         <myamount> #Mutez(Amount) </myamount>
     requires Amount ==Int 0
      andBool notBool Address in_keys(Tokens)
@@ -73,7 +73,7 @@ module LQT-TOKEN-GETALLOWANCE-SPEC
         <stack> .Stack </stack>
         <allowances> Allowances </allowances>
         <nonce> #Nonce(Nonce => Nonce +Int 1) </nonce>
-        <operations> _ => [ Transfer_tokens {Allowances[Pair Owner Spender]}:>Int #Mutez(0) Callback (Nonce) ] ;; .InternalList </operations>
+        <operations> _ => [| Transfer_tokens {Allowances[Pair Owner Spender]}:>Int #Mutez(0) Callback (Nonce) |] ;; .InternalList </operations>
         <myamount> #Mutez(Amount) </myamount>
     requires Amount ==Int 0
      andBool (Pair Owner Spender) in_keys(Allowances)
@@ -82,7 +82,7 @@ module LQT-TOKEN-GETALLOWANCE-SPEC
         <stack> .Stack </stack>
         <allowances> Allowances </allowances>
         <nonce> #Nonce(Nonce => Nonce +Int 1) </nonce>
-        <operations> _ => [ Transfer_tokens 0 #Mutez(0) Callback (Nonce) ] ;; .InternalList </operations>
+        <operations> _ => [| Transfer_tokens 0 #Mutez(0) Callback (Nonce) |] ;; .InternalList </operations>
         <myamount> #Mutez(Amount) </myamount>
     requires Amount ==Int 0
      andBool notBool (Pair Owner Spender) in_keys(Allowances)

--- a/tests/proofs/multisig-spec.md
+++ b/tests/proofs/multisig-spec.md
@@ -41,8 +41,8 @@ We use the `numValidSigs` function to show each iteration maintains the invarian
 
 ```k
   syntax Int ::= numValidSigs(sigs: InternalList, keys: InternalList) [function, smtlib(numValidSigs)]
-  rule numValidSigs([ Some #Signature(_) ] ;; Sigs, [ #Key(_) ] ;; Keys) => 1 +Int numValidSigs(Sigs, Keys) [simplification]
-  rule numValidSigs([ None ] ;; Sigs, _K ;; Keys) => numValidSigs(Sigs, Keys) [simplification]
+  rule numValidSigs([| Some #Signature(_) |] ;; Sigs, [| #Key(_) |] ;; Keys) => 1 +Int numValidSigs(Sigs, Keys) [simplification]
+  rule numValidSigs([| None |] ;; Sigs, _K ;; Keys) => numValidSigs(Sigs, Keys) [simplification]
   rule numValidSigs(_, .InternalList) => 0 [simplification]
 ```
 

--- a/tests/proofs/return-spec.k
+++ b/tests/proofs/return-spec.k
@@ -25,7 +25,7 @@ module RETURN-SPEC
           } ;
           PAIR .AnnotationList
         } => .K </k>
-        <stack> [ (pair unit unit) Pair Unit Unit ] ; .Stack => [ (pair (list operation) unit) Pair [ Transfer_tokens Unit #Mutez(A) #Address("SourceAddr") . %default ?_ ] ;; .InternalList Unit ] ; .Stack </stack>
+        <stack> [ (pair unit unit) Pair Unit Unit ] ; .Stack => [ (pair (list operation) unit) Pair [| Transfer_tokens Unit #Mutez(A) #Address("SourceAddr") . %default ?_ |] ;; .InternalList Unit ] ; .Stack </stack>
         <paramtype> %default |-> unit .AnnotationList </paramtype>
         <storagetype> unit .AnnotationList </storagetype>
         <mybalance> #Mutez(0) </mybalance>

--- a/tests/unit/push_pair_00.tzt
+++ b/tests/unit/push_pair_00.tzt
@@ -1,0 +1,3 @@
+code { PUSH (pair string string string) (Pair "Hello" "World" "!") ; DROP } ;
+input  { } ;
+output { }

--- a/tests/unit/push_pair_01.tzt
+++ b/tests/unit/push_pair_01.tzt
@@ -1,0 +1,3 @@
+code { PUSH (pair (pair nat string) string nat) (Pair (Pair 5 "Hello") "World" 6) ; DROP } ;
+input  { } ;
+output { }

--- a/tests/unit/push_pair_02.tzt
+++ b/tests/unit/push_pair_02.tzt
@@ -1,0 +1,3 @@
+code { PUSH (pair string string) (Pair "Hello" "World") ; DROP } ;
+input  { } ;
+output { }

--- a/tests/unit/push_pair_03.tzt
+++ b/tests/unit/push_pair_03.tzt
@@ -1,0 +1,3 @@
+code { PUSH (pair string string string) (Pair "Hello" (Pair "World" "!")) ; DROP } ;
+input  { } ;
+output { }

--- a/tests/unit/push_pair_04.tzt
+++ b/tests/unit/push_pair_04.tzt
@@ -1,0 +1,3 @@
+code { PUSH (pair string (pair string string)) (Pair "Hello" "World" "!") ; DROP } ;
+input  { } ;
+output { }


### PR DESCRIPTION
This PR updates the Tezos submodule from v7 to v10 and also fixes some build issues that I had on OSX.

### Makefile

- build: fix build command parsing on OSX by removing some spaces/adding extra quotes
- build: simplfy kompile invocation: only set needed options

### Tezos Submodule Build

- build: install rustup in CI container for later tezos
- tezos: bump from v7 to v10 (current version, but will probably be upgraded soon)

### K-Michelson

- expand parser to support new pair syntax (required for cross compatibility test harness support)
- update internal list syntax to avoid ambiguity due to new pair syntax
- add tests for new pair syntax
- fix cross test harness to support new pair syntax
- disable 2 tests that do not seem to be compatible with tezos v10
- update proof tests to use new internal list notation

**NOTE:** We probably do not support all features of v10. We should figure out what features are missing at some point.