### PR TITLE
Fix a typo: structrual -> structural

### DIFF
--- a/michelson.md
+++ b/michelson.md
@@ -493,7 +493,7 @@ We handle sequence and block semantics here.
 
 ```k
   rule I:Instruction ; Is => I ~> Is [structural]
-  rule {}                 => .K      [structrual]
+  rule {}                 => .K      [structural]
   rule { Is:DataList }    => Is      [structural]
 ```
 


### PR DESCRIPTION
This solves the issue #341 