### PR TITLE
Deprecate old `kprove` tool

### DIFF
--- a/kmich
+++ b/kmich
@@ -58,7 +58,7 @@ run_prove() {
     export K_OPTS=-Xmx8G
 
     ! $debug || set -x
-    kprove --directory "$backend_dir" "$run_file" --def-module "$def_module" "${additional_proof_args[@]}" "${extra_args[@]}" "$@"
+    kprove-legacy --directory "$backend_dir" "$run_file" --def-module "$def_module" "${additional_proof_args[@]}" "${extra_args[@]}" "$@"
 }
 
 run_interpret() {


### PR DESCRIPTION
This PR switches `kwasm prove` over to `kprove-legacy`, in preparation for `kprovex` being renamed.